### PR TITLE
update NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ### Miscellaneous
 * Updated R version requirement to >= 3.6.
-* Removed deprecated package`utils.nest` from imports and now use `checkmate` for validation functions.
+* Removed deprecated package `utils.nest` from imports and now use `checkmate` for validation functions.
 * Removed deprecated dependency `test.nest`.
 
 # random.cdisc.data 0.3.12


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/93

Note as this is rcd and is not released there is no pre-release branch and so this can be merged into main.

@pawelru @dinakar29 : as rcd is no longer released in NEST - it becomes a dev-only package like staged.deps and therefore can be "released" to devs as and when required. A process should be put in place for this otherwise the version bump will just keep growing and growing and the latest "release" will be very out of date (the way I did this for staged.deps was when a significant feature was ready I released it with an announcement to NEST - but I guess it shouldn't just rely on me)
