### PR TITLE
113 adding checkmate radpp

### DIFF
--- a/R/radpp.R
+++ b/R/radpp.R
@@ -5,7 +5,7 @@
 #' @param ppspec (`string`)\cr specimen material type.
 #' @param paramcd (`character`)\cr parameter code.
 #' @param param (`character`)\cr parameters.
-#' @param paramu (`string`)\cr Analysis value unit value.
+#' @param paramu (`character`)\cr Analysis value unit value.
 #' @param aval_mean (`vector`)\cr the mean for corresponding parameter.
 #' @param visit_format (`string`)\cr the visit format to produce AVISIT in the dataset.
 #' @param n_days (`integer`)\cr the number days that will be included to produce AVISIT in the dataset.
@@ -40,12 +40,12 @@ radpp <- function(ADSL, # nolint,
   }
 
   checkmate::assert_character(ppcat)
-  checkmate::assert_character(ppspec)
+  checkmate::assert_string(ppspec)
   checkmate::assert_character(paramcd)
   checkmate::assert_character(param)
   checkmate::assert_character(paramu)
-  checkmate::assert_numeric(aval_mean)
-  checkmate::assert_character(visit_format)
+  checkmate::assert_vector(aval_mean)
+  checkmate::assert_string(visit_format)
   checkmate::assert_integer(n_days)
   checkmate::assert_number(seed, null.ok = TRUE)
   checkmate::assert_numeric(na_percentage)

--- a/man/radpp.Rd
+++ b/man/radpp.Rd
@@ -31,7 +31,7 @@ radpp(
 
 \item{param}{(`character`)\cr parameters.}
 
-\item{paramu}{(`string`)\cr Analysis value unit value.}
+\item{paramu}{(`character`)\cr Analysis value unit value.}
 
 \item{aval_mean}{(`vector`)\cr the mean for corresponding parameter.}
 


### PR DESCRIPTION
Fixes #113 

NOTE: the param would not pass assertion with the original data type so it was necessary to change the param data type. documentation has been updated.