### PR TITLE
Consistent lowercase dataset names

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,5 @@
 linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
   cyclocomp_linter = NULL,
-  object_usage_linter = NULL,
-  object_name_linter = NULL
+  object_usage_linter = NULL
   )

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
 * Improved usability of examples.
 * Renamed `random.cdisc.data.R` file to `package.R` and cleaned up contents.
 * Added more detailed documentation for function parameters.
+* Converted all dataset names to lowercase/snake case for consistency with other NEST packages.
 
 # random.cdisc.data 0.3.13
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 * Renamed `random.cdisc.data.R` file to `package.R` and cleaned up contents.
 * Added more detailed documentation for function parameters.
 * Converted all dataset names to lowercase/snake case for consistency with other NEST packages.
+* Converted `ADSL` argument to `adsl`, `ADPC` to `adpc`, `event.descr` to `event_descr`, 
+  and `censor.descr` to `censor_descr` for all applicable rdata functions.
 
 # random.cdisc.data 0.3.13
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # random.cdisc.data 0.3.13.9056
 
+### Breaking changes
+* Renamed `ADSL` argument to `adsl` in `radab`, `radae`, `radaette`, `radcm`, `raddv`, `radeg`, `radex`, `radhy`, `radlb`,
+  `radmh`, `radpc`, `radpp`, `radqlqc`, `radqs`, `radrs`, `radsaftte`, `radsub`, `radtr`, `radtte`, `radvs`, and `get_qs_data`.
+* Renamed `ADPC` argument to `adpc` in `radab`.
+* Renamed `event.descr` argument `event_descr` and `censor.descr` argument to `censor_descr` in `radaette` and `adtte`.
+
 ### New features
 * Added new random dataset generator: Anti-Drug Antibody Analysis Dataset (`radab`).
 
@@ -42,8 +48,6 @@
 * Renamed `random.cdisc.data.R` file to `package.R` and cleaned up contents.
 * Added more detailed documentation for function parameters.
 * Converted all dataset names to lowercase/snake case for consistency with other NEST packages.
-* Converted `ADSL` argument to `adsl`, `ADPC` to `adpc`, `event.descr` to `event_descr`, 
-  and `censor.descr` to `censor_descr` for all applicable rdata functions.
 
 # random.cdisc.data 0.3.13
 

--- a/R/argument_convention.R
+++ b/R/argument_convention.R
@@ -12,7 +12,7 @@
 #'   \item{`percentage` (`proportion`)\cr Percentage of elements to be replaced with `NA`.
 #'   If `NA`, `na_percentage` is used as a default.}
 #' }
-#' @param ADSL (`data.frame`)\cr Subject-Level Analysis Dataset (ADSL).
+#' @param adsl (`data.frame`)\cr Subject-Level Analysis Dataset (ADSL).
 #' @param lookup (`data.frame`)\cr Additional parameters.
 #' @param lookup_aag (`data.frame`)\cr Additional metadata parameters.
 #' @param param (`character vector`)\cr Parameter values.

--- a/R/radab.R
+++ b/R/radab.R
@@ -7,7 +7,7 @@
 #'
 #' @inheritParams argument_convention
 #' @inheritParams radpc
-#' @param ADPC (`data.frame`)\cr Pharmacokinetics Analysis Dataset.
+#' @param adpc (`data.frame`)\cr Pharmacokinetics Analysis Dataset.
 #' @template param_cached
 #' @templateVar data adab
 #'
@@ -19,12 +19,12 @@
 #' @examples
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
-#' ADPC <- radpc(adsl, seed = 2, duration = 9 * 7)
+#' adpc <- radpc(adsl, seed = 2, duration = 9 * 7)
 #'
-#' ADAB <- radab(adsl, ADPC, seed = 2)
-#' ADAB
+#' adab <- radab(adsl, adpc, seed = 2)
+#' adab
 radab <- function(adsl,
-                  ADPC,
+                  adpc,
                   constants = c(D = 100, ka = 0.8, ke = 1),
                   paramcd = c(
                     "R1800000", "RESULT1", "R1800001", "RESULT2", "ADASTAT1", "INDUCD1", "ENHANC1",
@@ -61,7 +61,7 @@ radab <- function(adsl,
     return(get_cached_data("cadpc"))
   }
 
-  checkmate::assert_data_frame(ADPC)
+  checkmate::assert_data_frame(adpc)
   checkmate::assert_subset(names(constants), c("D", "ka", "ke"))
   checkmate::assert_number(seed, null.ok = TRUE)
   checkmate::assert_number(na_percentage, lower = 0, upper = 1, na.ok = TRUE)
@@ -80,14 +80,14 @@ radab <- function(adsl,
   param_init_list <- relvar_init(param, paramcd)
   unit_init_list <- relvar_init(param, avalu)
 
-  ADPC <- ADPC %>% dplyr::filter(ASMED == "PLASMA")
-  ADAB <- expand.grid(
+  adpc <- adpc %>% dplyr::filter(ASMED == "PLASMA")
+  adab <- expand.grid(
     STUDYID = unique(adsl$STUDYID),
     USUBJID = unique(adsl$USUBJID),
-    VISIT = unique(ADPC$VISIT),
+    VISIT = unique(adpc$VISIT),
     PARAM = as.factor(param_init_list$relvar1),
     PARCAT1 = "A: Drug X Antibody",
-    PCTPT = unique(ADPC$PCTPT),
+    PCTPT = unique(adpc$PCTPT),
     stringsAsFactors = FALSE
   )
 
@@ -95,11 +95,11 @@ radab <- function(adsl,
     "Antibody titer units", "Neutralizing Antibody titer units",
     "ADA interpreted per sample result", "NAB interpreted per sample result"
   )
-  aval_random <- stats::rnorm(nrow(unique(ADAB %>% dplyr::select(USUBJID, VISIT))), mean = 1, sd = 0.2)
-  aval_random <- cbind(unique(ADAB %>% dplyr::select(USUBJID, VISIT)), AVAL1 = aval_random)
+  aval_random <- stats::rnorm(nrow(unique(adab %>% dplyr::select(USUBJID, VISIT))), mean = 1, sd = 0.2)
+  aval_random <- cbind(unique(adab %>% dplyr::select(USUBJID, VISIT)), AVAL1 = aval_random)
 
-  ADAB <- ADAB %>% dplyr::left_join(aval_random, by = c("USUBJID", "VISIT"))
-  ADAB <- ADAB %>%
+  adab <- adab %>% dplyr::left_join(aval_random, by = c("USUBJID", "VISIT"))
+  adab <- adab %>%
     dplyr::mutate(
       AVAL2 = ifelse(AVAL1 >= 1, AVAL1, NA),
       AVALC = dplyr::case_when(
@@ -116,22 +116,22 @@ radab <- function(adsl,
     dplyr::select(-c(AVAL1, AVAL2))
 
   # assign related variable values: PARAMxPARAMCD are related
-  ADAB <- ADAB %>% rel_var(
+  adab <- adab %>% rel_var(
     var_name = "PARAMCD",
     related_var = "PARAM",
     var_values = param_init_list$relvar2
   )
 
   # assign related variable values: PARAMxAVALU are related
-  ADAB <- ADAB %>% rel_var(
+  adab <- adab %>% rel_var(
     var_name = "AVALU",
     related_var = "PARAM",
     var_values = unit_init_list$relvar2
   )
 
-  # retrieve other variables from ADPC
-  ADAB <- ADAB %>%
-    dplyr::inner_join(ADPC %>% dplyr::select(
+  # retrieve other variables from adpc
+  adab <- adab %>%
+    dplyr::inner_join(adpc %>% dplyr::select(
       STUDYID,
       USUBJID,
       VISIT,
@@ -148,12 +148,12 @@ radab <- function(adsl,
       unique(), by = c("STUDYID", "USUBJID", "VISIT", "PCTPT")) %>%
     dplyr::select(-PCTPT)
 
-  # mutate time from dose variables from ADPC to convert into Days
-  ADAB <- ADAB %>% dplyr::mutate_at(c("ARELTM1", "NRELTM1", "ARELTM2", "NRELTM2"), ~ . / 24)
-  ADAB <- ADAB %>%
+  # mutate time from dose variables from adpc to convert into Days
+  adab <- adab %>% dplyr::mutate_at(c("ARELTM1", "NRELTM1", "ARELTM2", "NRELTM2"), ~ . / 24)
+  adab <- adab %>%
     dplyr::mutate(
       RELTMU = "day",
-      ADABLFL = "Y",
+      adabLFL = "Y",
       ADAPBLFL = ifelse(ACTARM == "A: Drug X" | ACTARM == "C: Combination", "Y",
         NA
       ),
@@ -166,7 +166,7 @@ radab <- function(adsl,
     dplyr::ungroup()
 
   # create temporary flags to derive subject-level variables
-  adab_subj <- ADAB %>%
+  adab_subj <- adab %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(
       pos_bl = any(PARAM == "ADA interpreted per sample result" &
@@ -221,11 +221,11 @@ radab <- function(adsl,
     unique()
 
   # add flags to ADAB dataset
-  ADAB <- ADAB %>%
+  adab <- adab %>%
     dplyr::left_join(adab_subj, by = c("USUBJID", "NRELTM1"))
 
   # derive subject-level variables
-  ADAB[!(ADAB$PARAM %in% visit_lvl_params), ] <- ADAB %>%
+  adab[!(adab$PARAM %in% visit_lvl_params), ] <- adab %>%
     dplyr::filter(!(PARAM %in% visit_lvl_params)) %>%
     dplyr::mutate(
       AVALC = dplyr::case_when(
@@ -303,8 +303,8 @@ radab <- function(adsl,
       )
     )
 
-  # remove intermediate flag variables from ADAB
-  ADAB <- ADAB %>%
+  # remove intermediate flag variables from adab
+  adab <- adab %>%
     dplyr::select(-c(
       pos_bl,
       pos_bl_nab,
@@ -319,8 +319,8 @@ radab <- function(adsl,
     ))
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADAB <- mutate_na(ds = ADAB, na_vars = na_vars, na_percentage = na_percentage)
+    adab <- mutate_na(ds = adab, na_vars = na_vars, na_percentage = na_percentage)
   }
 
-  ADAB <- apply_metadata(ADAB, "metadata/ADAB.yml")
+  adab <- apply_metadata(adab, "metadata/adab.yml")
 }

--- a/R/radab.R
+++ b/R/radab.R
@@ -18,12 +18,12 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
-#' ADPC <- radpc(ADSL, seed = 2, duration = 9 * 7)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
+#' ADPC <- radpc(adsl, seed = 2, duration = 9 * 7)
 #'
-#' ADAB <- radab(ADSL, ADPC, seed = 2)
+#' ADAB <- radab(adsl, ADPC, seed = 2)
 #' ADAB
-radab <- function(ADSL,
+radab <- function(adsl,
                   ADPC,
                   constants = c(D = 100, ka = 0.8, ke = 1),
                   paramcd = c(
@@ -82,8 +82,8 @@ radab <- function(ADSL,
 
   ADPC <- ADPC %>% dplyr::filter(ASMED == "PLASMA")
   ADAB <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = unique(ADSL$USUBJID),
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = unique(adsl$USUBJID),
     VISIT = unique(ADPC$VISIT),
     PARAM = as.factor(param_init_list$relvar1),
     PARCAT1 = "A: Drug X Antibody",

--- a/R/radab.R
+++ b/R/radab.R
@@ -153,7 +153,7 @@ radab <- function(adsl,
   adab <- adab %>%
     dplyr::mutate(
       RELTMU = "day",
-      adabLFL = "Y",
+      ADABLFL = "Y",
       ADAPBLFL = ifelse(ACTARM == "A: Drug X" | ACTARM == "C: Combination", "Y",
         NA
       ),
@@ -322,5 +322,5 @@ radab <- function(adsl,
     adab <- mutate_na(ds = adab, na_vars = na_vars, na_percentage = na_percentage)
   }
 
-  adab <- apply_metadata(adab, "metadata/adab.yml")
+  adab <- apply_metadata(adab, "metadata/ADAB.yml")
 }

--- a/R/radae.R
+++ b/R/radae.R
@@ -19,9 +19,9 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
+#' adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 #'
-#' ADAE <- radae(ADSL, seed = 2)
+#' ADAE <- radae(adsl, seed = 2)
 #' ADAE
 #'
 #' # Add metadata.
@@ -39,7 +39,7 @@
 #'   ), stringsAsFactors = FALSE
 #' )
 #'
-#' ADAE <- radae(ADSL, lookup_aag = AAG)
+#' ADAE <- radae(adsl, lookup_aag = AAG)
 #'
 #' with(
 #'   ADAE,
@@ -48,7 +48,7 @@
 #'     table(AEDECOD, CQ01NAM)
 #'   )
 #' )
-radae <- function(ADSL,
+radae <- function(adsl,
                   max_n_aes = 10L,
                   lookup = NULL,
                   lookup_aag = NULL,
@@ -65,7 +65,7 @@ radae <- function(ADSL,
     return(get_cached_data("cadae"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_integer(max_n_aes, len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
   checkmate::assert_number(na_percentage, lower = 0, upper = 1)
@@ -111,7 +111,7 @@ radae <- function(ADSL,
   }
 
   if (!is.null(seed)) set.seed(seed)
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   ADAE <- Map(
     function(id, sid) {
@@ -123,8 +123,8 @@ radae <- function(ADSL,
         STUDYID = sid
       )
     },
-    ADSL$USUBJID,
-    ADSL$STUDYID
+    adsl$USUBJID,
+    adsl$STUDYID
   ) %>%
     Reduce(rbind, .) %>%
     `[`(c(10, 11, 1, 2, 3, 4, 5, 6, 7, 8, 9)) %>%
@@ -141,8 +141,8 @@ radae <- function(ADSL,
     USUBJID = "Unique Subject Identifier"
   )
 
-  # merge ADSL to be able to add AE date and study day variables
-  ADAE <- dplyr::inner_join(ADAE, ADSL, by = c("STUDYID", "USUBJID")) %>%
+  # merge adsl to be able to add AE date and study day variables
+  ADAE <- dplyr::inner_join(ADAE, adsl, by = c("STUDYID", "USUBJID")) %>%
     dplyr::rowwise() %>%
     dplyr::mutate(TRTENDT = lubridate::date(dplyr::case_when(
       is.na(TRTEDTM) ~ lubridate::floor_date(lubridate::date(TRTSDTM) + study_duration_secs, unit = "day"),

--- a/R/radae.R
+++ b/R/radae.R
@@ -286,7 +286,7 @@ radae <- function(adsl,
   }
 
   # apply metadata
-  adae <- apply_metadata(adae, "metadata/adae.yml")
+  adae <- apply_metadata(adae, "metadata/ADAE.yml")
 
   return(adae)
 }

--- a/R/radaette.R
+++ b/R/radaette.R
@@ -22,11 +22,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADAETTE <- radaette(ADSL, seed = 2)
+#' ADAETTE <- radaette(adsl, seed = 2)
 #' ADAETTE
-radaette <- function(ADSL,
+radaette <- function(adsl,
                      event.descr = NULL,
                      censor.descr = NULL,
                      lookup = NULL,
@@ -39,7 +39,7 @@ radaette <- function(ADSL,
     return(get_cached_data("cadaette"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(censor.descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(event.descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
@@ -67,7 +67,7 @@ radaette <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   evntdescr_sel <- if (!is.null(event.descr)) {
     event.descr
@@ -118,12 +118,12 @@ radaette <- function(ADSL,
   paramcd_hy <- c("HYSTTEUL", "HYSTTEBL")
   param_hy <- c("Time to Hy's Law Elevation in relation to ULN", "Time to Hy's Law Elevation in relation to Baseline")
   param_init_list <- relvar_init(param_hy, paramcd_hy)
-  adsl_hy <- dplyr::select(ADSL, "STUDYID", "USUBJID", "TRTSDTM", "SITEID", "ARM")
+  adsl_hy <- dplyr::select(adsl, "STUDYID", "USUBJID", "TRTSDTM", "SITEID", "ARM")
 
   # create all combinations of unique values in STUDYID, USUBJID, PARAM, AVISIT
   adaette_hy <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
     stringsAsFactors = FALSE
   )
@@ -213,7 +213,7 @@ radaette <- function(ADSL,
     )
   }
 
-  ADAETTE <- split(ADSL, ADSL$USUBJID) %>%
+  ADAETTE <- split(adsl, adsl$USUBJID) %>%
     lapply(function(patient_info) {
       patient_data <- random_patient_data(patient_info)
       lookup_arm <- lookup_ADAETTE %>%
@@ -239,7 +239,7 @@ radaette <- function(ADSL,
 
   ADAETTE <- dplyr::inner_join(
     dplyr::select(ADAETTE, -"SITEID", -"ARM"),
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::group_by(USUBJID) %>%

--- a/R/radaette.R
+++ b/R/radaette.R
@@ -262,7 +262,7 @@ radaette <- function(adsl,
   }
 
   # apply metadata
-  adaette <- apply_metadata(adaette, "metadata/adaette.yml")
+  adaette <- apply_metadata(adaette, "metadata/ADAETTE.yml")
 
   return(adaette)
 }

--- a/R/radaette.R
+++ b/R/radaette.R
@@ -10,8 +10,8 @@
 #' Keys: `STUDYID`, `USUBJID`, `PARAMCD`
 #'
 #' @inheritParams argument_convention
-#' @param event.descr (`character vector`)\cr Descriptions of events. Defaults to `NULL`.
-#' @param censor.descr (`character vector`)\cr Descriptions of censors. Defaults to `NULL`.
+#' @param event_descr (`character vector`)\cr Descriptions of events. Defaults to `NULL`.
+#' @param censor_descr (`character vector`)\cr Descriptions of censors. Defaults to `NULL`.
 #' @template param_cached
 #' @templateVar data adaette
 #'
@@ -27,8 +27,8 @@
 #' adaette <- radaette(adsl, seed = 2)
 #' adaette
 radaette <- function(adsl,
-                     event.descr = NULL,
-                     censor.descr = NULL,
+                     event_descr = NULL,
+                     censor_descr = NULL,
                      lookup = NULL,
                      seed = NULL,
                      na_percentage = 0,
@@ -40,8 +40,8 @@ radaette <- function(adsl,
   }
 
   checkmate::assert_data_frame(adsl)
-  checkmate::assert_character(censor.descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
-  checkmate::assert_character(event.descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
+  checkmate::assert_character(censor_descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
+  checkmate::assert_character(event_descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
   checkmate::assert_number(na_percentage, lower = 0, upper = 1)
   checkmate::assert_true(na_percentage < 1)
@@ -69,14 +69,14 @@ radaette <- function(adsl,
   }
   study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
-  evntdescr_sel <- if (!is.null(event.descr)) {
-    event.descr
+  evntdescr_sel <- if (!is.null(event_descr)) {
+    event_descr
   } else {
     "Preferred Term"
   }
 
-  cnsdtdscr_sel <- if (!is.null(censor.descr)) {
-    censor.descr
+  cnsdtdscr_sel <- if (!is.null(censor_descr)) {
+    censor_descr
   } else {
     c(
       "Clinical Cut Off",

--- a/R/radaette.R
+++ b/R/radaette.R
@@ -24,8 +24,8 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADAETTE <- radaette(adsl, seed = 2)
-#' ADAETTE
+#' adaette <- radaette(adsl, seed = 2)
+#' adaette
 radaette <- function(adsl,
                      event.descr = NULL,
                      censor.descr = NULL,
@@ -47,7 +47,7 @@ radaette <- function(adsl,
   checkmate::assert_true(na_percentage < 1)
 
   checkmate::assert_data_frame(lookup, null.ok = TRUE)
-  lookup_ADAETTE <- if (!is.null(lookup)) {
+  lookup_adaette <- if (!is.null(lookup)) {
     lookup
   } else {
     tibble::tribble(
@@ -213,10 +213,10 @@ radaette <- function(adsl,
     )
   }
 
-  ADAETTE <- split(adsl, adsl$USUBJID) %>%
+  adaette <- split(adsl, adsl$USUBJID) %>%
     lapply(function(patient_info) {
       patient_data <- random_patient_data(patient_info)
-      lookup_arm <- lookup_ADAETTE %>%
+      lookup_arm <- lookup_adaette %>%
         dplyr::filter(ARM == as.character(patient_info$ARMCD))
       ae_data <- split(lookup_arm, lookup_arm$CATCD) %>%
         lapply(random_ae_data, patient_data = patient_data, patient_info = patient_info) %>%
@@ -229,16 +229,16 @@ radaette <- function(adsl,
       USUBJID = "Unique Subject Identifier"
     )
 
-  ADAETTE <- var_relabel(
-    ADAETTE,
+  adaette <- var_relabel(
+    adaette,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
 
-  ADAETTE <- rbind(ADAETTE, adaette_hy)
+  adaette <- rbind(adaette, adaette_hy)
 
-  ADAETTE <- dplyr::inner_join(
-    dplyr::select(ADAETTE, -"SITEID", -"ARM"),
+  adaette <- dplyr::inner_join(
+    dplyr::select(adaette, -"SITEID", -"ARM"),
     adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
@@ -258,11 +258,11 @@ radaette <- function(adsl,
     )
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADAETTE <- dplyr::mutate(ds = ADAETTE, na_vars = na_vars, na_percentage = na_percentage)
+    adaette <- dplyr::mutate(ds = adaette, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # apply metadata
-  ADAETTE <- apply_metadata(ADAETTE, "metadata/ADAETTE.yml")
+  adaette <- apply_metadata(adaette, "metadata/adaette.yml")
 
-  return(ADAETTE)
+  return(adaette)
 }

--- a/R/radcm.R
+++ b/R/radcm.R
@@ -20,14 +20,14 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADCM <- radcm(ADSL, seed = 2)
+#' ADCM <- radcm(adsl, seed = 2)
 #' ADCM
 #'
-#' ADCM_WHO <- radcm(ADSL, seed = 2, who_coding = TRUE)
+#' ADCM_WHO <- radcm(adsl, seed = 2, who_coding = TRUE)
 #' ADCM_WHO
-radcm <- function(ADSL,
+radcm <- function(adsl,
                   max_n_cms = 10L,
                   lookup = NULL,
                   seed = NULL,
@@ -40,7 +40,7 @@ radcm <- function(ADSL,
     return(get_cached_data("cadcm"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_integer(max_n_cms, len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
   checkmate::assert_number(na_percentage, lower = 0, upper = 1)
@@ -68,7 +68,7 @@ radcm <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   ADCM <- Map(function(id, sid) {
     n_cms <- sample(c(0, seq_len(max_n_cms)), 1)
@@ -78,7 +78,7 @@ radcm <- function(ADSL,
       USUBJID = id,
       STUDYID = sid
     )
-  }, ADSL$USUBJID, ADSL$STUDYID) %>%
+  }, adsl$USUBJID, adsl$STUDYID) %>%
     Reduce(rbind, .) %>%
     `[`(c(4, 5, 1, 2, 3)) %>%
     dplyr::mutate(CMCAT = CMCLAS)
@@ -92,7 +92,7 @@ radcm <- function(ADSL,
   # merge ADSL to be able to add CM date and study day variables
   ADCM <- dplyr::inner_join(
     ADCM,
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::rowwise() %>%

--- a/R/radcm.R
+++ b/R/radcm.R
@@ -22,11 +22,11 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADCM <- radcm(adsl, seed = 2)
-#' ADCM
+#' adcm <- radcm(adsl, seed = 2)
+#' adcm
 #'
-#' ADCM_WHO <- radcm(adsl, seed = 2, who_coding = TRUE)
-#' ADCM_WHO
+#' adcm_who <- radcm(adsl, seed = 2, who_coding = TRUE)
+#' adcm_who
 radcm <- function(adsl,
                   max_n_cms = 10L,
                   lookup = NULL,
@@ -70,7 +70,7 @@ radcm <- function(adsl,
   }
   study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
-  ADCM <- Map(function(id, sid) {
+  adcm <- Map(function(id, sid) {
     n_cms <- sample(c(0, seq_len(max_n_cms)), 1)
     i <- sample(seq_len(nrow(lookup_cm)), n_cms, TRUE)
     dplyr::mutate(
@@ -83,15 +83,15 @@ radcm <- function(adsl,
     `[`(c(4, 5, 1, 2, 3)) %>%
     dplyr::mutate(CMCAT = CMCLAS)
 
-  ADCM <- var_relabel(
-    ADCM,
+  adcm <- var_relabel(
+    adcm,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
 
   # merge ADSL to be able to add CM date and study day variables
-  ADCM <- dplyr::inner_join(
-    ADCM,
+  adcm <- dplyr::inner_join(
+    adcm,
     adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
@@ -115,7 +115,7 @@ radcm <- function(adsl,
     dplyr::ungroup() %>%
     dplyr::arrange(STUDYID, USUBJID, ASTDTM)
 
-  ADCM <- ADCM %>%
+  adcm <- adcm %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(CMSEQ = seq_len(dplyr::n())) %>%
     dplyr::mutate(ASEQ = CMSEQ) %>%
@@ -166,7 +166,7 @@ radcm <- function(adsl,
   if (who_coding) {
     n_cmdecod_path2 <- ceiling(nrow(lookup_cm) / 2)
     cmdecod_path2 <- sample(lookup_cm$CMDECOD, n_cmdecod_path2)
-    ADCM_path2 <- ADCM %>%
+    adcm_path2 <- adcm %>%
       dplyr::filter(CMDECOD %in% cmdecod_path2) %>%
       dplyr::mutate(
         ATC1 = paste(ATC1, "p2"),
@@ -177,7 +177,7 @@ radcm <- function(adsl,
 
     n_cmdecod_path3 <- ceiling(length(cmdecod_path2) / 2)
     cmdecod_path3 <- sample(cmdecod_path2, n_cmdecod_path3)
-    ADCM_path3 <- ADCM %>%
+    adcm_path3 <- adcm %>%
       dplyr::filter(CMDECOD %in% cmdecod_path3) %>%
       dplyr::mutate(
         ATC1 = paste(ATC1, "p3"),
@@ -186,14 +186,14 @@ radcm <- function(adsl,
         ATC4 = paste(ATC4, "p3")
       )
 
-    ADCM <- dplyr::bind_rows(
-      ADCM,
-      ADCM_path2,
-      ADCM_path3
+    adcm <- dplyr::bind_rows(
+      adcm,
+      adcm_path2,
+      adcm_path3
     )
   }
 
-  ADCM <- ADCM %>%
+  adcm <- adcm %>%
     dplyr::mutate(
       ATC1CD = ATC1,
       ATC2CD = ATC2,
@@ -202,11 +202,11 @@ radcm <- function(adsl,
     )
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADCM <- mutate_na(ds = ADCM, na_vars = na_vars, na_percentage = na_percentage)
+    adcm <- mutate_na(ds = adcm, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # apply metadata
-  ADCM <- apply_metadata(ADCM, "metadata/ADCM.yml")
+  adcm <- apply_metadata(adcm, "metadata/adcm.yml")
 
-  return(ADCM)
+  return(adcm)
 }

--- a/R/radcm.R
+++ b/R/radcm.R
@@ -206,7 +206,7 @@ radcm <- function(adsl,
   }
 
   # apply metadata
-  adcm <- apply_metadata(adcm, "metadata/adcm.yml")
+  adcm <- apply_metadata(adcm, "metadata/ADCM.yml")
 
   return(adcm)
 }

--- a/R/raddv.R
+++ b/R/raddv.R
@@ -139,7 +139,7 @@ raddv <- function(adsl,
   }
 
   # apply metadata
-  addv <- apply_metadata(addv, "metadata/addv.yml")
+  addv <- apply_metadata(addv, "metadata/ADDV.yml")
 
   return(addv)
 }

--- a/R/raddv.R
+++ b/R/raddv.R
@@ -20,11 +20,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADDV <- raddv(ADSL, seed = 2)
+#' ADDV <- raddv(adsl, seed = 2)
 #' ADDV
-raddv <- function(ADSL,
+raddv <- function(adsl,
                   max_n_dv = 3L,
                   p_dv = 0.15,
                   lookup = NULL,
@@ -40,7 +40,7 @@ raddv <- function(ADSL,
     return(get_cached_data("caddv"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_integer(max_n_dv, len = 1, lower = 1, any.missing = FALSE)
   checkmate::assert_number(p_dv, lower = .Machine$double.xmin, upper = 1)
   checkmate::assert_number(seed, null.ok = TRUE)
@@ -48,7 +48,7 @@ raddv <- function(ADSL,
   checkmate::assert_true(na_percentage < 1)
 
   if (!is.null(seed)) set.seed(seed)
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   checkmate::assert_data_frame(lookup, null.ok = TRUE)
   lookup_dv <- if (!is.null(lookup)) {
@@ -96,8 +96,8 @@ raddv <- function(ADSL,
         STUDYID = sid
       )
     },
-    ADSL$USUBJID,
-    ADSL$STUDYID
+    adsl$USUBJID,
+    adsl$STUDYID
   ) %>%
     Reduce(rbind, .) %>%
     dplyr::mutate(DVSCAT = DVCAT)
@@ -109,7 +109,7 @@ raddv <- function(ADSL,
   )
 
   # merge ADSL to be able to add deviation date and study day variables
-  ADDV <- dplyr::inner_join(ADDV, ADSL, by = c("STUDYID", "USUBJID")) %>%
+  ADDV <- dplyr::inner_join(ADDV, adsl, by = c("STUDYID", "USUBJID")) %>%
     dplyr::rowwise() %>%
     dplyr::mutate(TRTENDT = lubridate::date(dplyr::case_when(
       is.na(TRTEDTM) ~ lubridate::floor_date(lubridate::date(TRTSDTM) + study_duration_secs, unit = "day"),

--- a/R/radeg.R
+++ b/R/radeg.R
@@ -22,14 +22,14 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADEG <- radeg(ADSL, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+#' ADEG <- radeg(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
 #' ADEG
 #'
-#' ADEG <- radeg(ADSL, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
+#' ADEG <- radeg(adsl, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
 #' ADEG
-radeg <- function(ADSL,
+radeg <- function(adsl,
                   egcat = c("INTERVAL", "INTERVAL", "MEASUREMENT", "FINDING"),
                   param = c(
                     "QT Duration",
@@ -56,7 +56,7 @@ radeg <- function(ADSL,
     return(get_cached_data("cadeg"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(egcat, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(param, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramcd, min.len = 1, any.missing = FALSE)
@@ -78,11 +78,11 @@ radeg <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   ADEG <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
     AVISIT = visit_schedule(visit_format = visit_format, n_assessments = n_assessments, n_days = n_days),
     stringsAsFactors = FALSE
@@ -130,7 +130,7 @@ radeg <- function(ADSL,
   ADEG <- ADEG[order(ADEG$STUDYID, ADEG$USUBJID, ADEG$PARAMCD, ADEG$AVISITN), ]
 
   ADEG <- Reduce(rbind, lapply(split(ADEG, ADEG$USUBJID), function(x) {
-    x$STUDYID <- ADSL$STUDYID[which(ADSL$USUBJID == x$USUBJID[1])]
+    x$STUDYID <- adsl$STUDYID[which(adsl$USUBJID == x$USUBJID[1])]
     x$ABLFL <- ifelse(toupper(visit_format) == "WEEK" & x$AVISIT == "BASELINE",
       "Y",
       ifelse(toupper(visit_format) == "CYCLE" & x$AVISIT == "CYCLE 1 DAY 1", "Y", "")
@@ -186,7 +186,7 @@ radeg <- function(ADSL,
   # merge ADSL to be able to add EG date and study day variables
   ADEG <- dplyr::inner_join(
     ADEG,
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::rowwise() %>%

--- a/R/radeg.R
+++ b/R/radeg.R
@@ -372,7 +372,7 @@ radeg <- function(adsl,
   }
 
   # apply metadata
-  adeg <- apply_metadata(adeg, "metadata/adeg.yml")
+  adeg <- apply_metadata(adeg, "metadata/ADEG.yml")
 
   return(adeg)
 }

--- a/R/radeg.R
+++ b/R/radeg.R
@@ -24,11 +24,11 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADEG <- radeg(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
-#' ADEG
+#' adeg <- radeg(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+#' adeg
 #'
-#' ADEG <- radeg(adsl, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
-#' ADEG
+#' adeg <- radeg(adsl, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
+#' adeg
 radeg <- function(adsl,
                   egcat = c("INTERVAL", "INTERVAL", "MEASUREMENT", "FINDING"),
                   param = c(
@@ -80,7 +80,7 @@ radeg <- function(adsl,
   }
   study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
-  ADEG <- expand.grid(
+  adeg <- expand.grid(
     STUDYID = unique(adsl$STUDYID),
     USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
@@ -89,47 +89,47 @@ radeg <- function(adsl,
   )
 
   # assign related variable values: PARAMxEGCAT are related
-  ADEG <- ADEG %>% rel_var(
+  adeg <- adeg %>% rel_var(
     var_name = "EGCAT",
     related_var = "PARAM",
     var_values = egcat_init_list$relvar2
   )
 
   # assign related variable values: PARAMxPARAMCD are related
-  ADEG <- ADEG %>% rel_var(
+  adeg <- adeg %>% rel_var(
     var_name = "PARAMCD",
     related_var = "PARAM",
     var_values = param_init_list$relvar2
   )
 
-  ADEG <- ADEG %>% dplyr::mutate(AVAL = dplyr::case_when(
-    PARAMCD == "QT" ~ stats::rnorm(nrow(ADEG), mean = 350, sd = 100),
-    PARAMCD == "RR" ~ stats::rnorm(nrow(ADEG), mean = 1050, sd = 300),
-    PARAMCD == "HR" ~ stats::rnorm(nrow(ADEG), mean = 70, sd = 20),
+  adeg <- adeg %>% dplyr::mutate(AVAL = dplyr::case_when(
+    PARAMCD == "QT" ~ stats::rnorm(nrow(adeg), mean = 350, sd = 100),
+    PARAMCD == "RR" ~ stats::rnorm(nrow(adeg), mean = 1050, sd = 300),
+    PARAMCD == "HR" ~ stats::rnorm(nrow(adeg), mean = 70, sd = 20),
     PARAMCD == "ECGINTP" ~ NA_real_
   ))
 
-  ADEG <- ADEG %>%
+  adeg <- adeg %>%
     dplyr::mutate(EGTESTCD = PARAMCD) %>%
     dplyr::mutate(EGTEST = PARAM)
 
-  ADEG <- ADEG %>% dplyr::mutate(AVISITN = dplyr::case_when(
+  adeg <- adeg %>% dplyr::mutate(AVISITN = dplyr::case_when(
     AVISIT == "SCREENING" ~ -1,
     AVISIT == "BASELINE" ~ 0,
     (grepl("^WEEK", AVISIT) | grepl("^CYCLE", AVISIT)) ~ as.numeric(AVISIT) - 2,
     TRUE ~ NA_real_
   ))
 
-  ADEG <- ADEG %>% rel_var(
+  adeg <- adeg %>% rel_var(
     var_name = "AVALU",
     related_var = "PARAM",
     var_values = unit_init_list$relvar2
   )
 
   # order to prepare for change from screening and baseline values
-  ADEG <- ADEG[order(ADEG$STUDYID, ADEG$USUBJID, ADEG$PARAMCD, ADEG$AVISITN), ]
+  adeg <- adeg[order(adeg$STUDYID, adeg$USUBJID, adeg$PARAMCD, adeg$AVISITN), ]
 
-  ADEG <- Reduce(rbind, lapply(split(ADEG, ADEG$USUBJID), function(x) {
+  adeg <- Reduce(rbind, lapply(split(adeg, adeg$USUBJID), function(x) {
     x$STUDYID <- adsl$STUDYID[which(adsl$USUBJID == x$USUBJID[1])]
     x$ABLFL <- ifelse(toupper(visit_format) == "WEEK" & x$AVISIT == "BASELINE",
       "Y",
@@ -138,29 +138,29 @@ radeg <- function(adsl,
     x
   }))
 
-  ADEG$BASE <- ifelse(ADEG$AVISITN >= 0, retain(ADEG, ADEG$AVAL, ADEG$ABLFL == "Y"), ADEG$AVAL)
+  adeg$BASE <- ifelse(adeg$AVISITN >= 0, retain(adeg, adeg$AVAL, adeg$ABLFL == "Y"), adeg$AVAL)
 
-  ADEG <- ADEG %>% dplyr::mutate(ANRLO = dplyr::case_when(
+  adeg <- adeg %>% dplyr::mutate(ANRLO = dplyr::case_when(
     PARAMCD == "QT" ~ 200,
     PARAMCD == "RR" ~ 600,
     PARAMCD == "HR" ~ 40,
     PARAMCD == "ECGINTP" ~ NA_real_
   ))
 
-  ADEG <- ADEG %>% dplyr::mutate(ANRHI = dplyr::case_when(
+  adeg <- adeg %>% dplyr::mutate(ANRHI = dplyr::case_when(
     PARAMCD == "QT" ~ 500,
     PARAMCD == "RR" ~ 1500,
     PARAMCD == "HR" ~ 100,
     PARAMCD == "ECGINTP" ~ NA_real_
   ))
 
-  ADEG <- ADEG %>% dplyr::mutate(ANRIND = factor(dplyr::case_when(
+  adeg <- adeg %>% dplyr::mutate(ANRIND = factor(dplyr::case_when(
     AVAL < ANRLO ~ "LOW",
     AVAL >= ANRLO & AVAL <= ANRHI ~ "NORMAL",
     AVAL > ANRHI ~ "HIGH"
   )))
 
-  ADEG <- ADEG %>%
+  adeg <- adeg %>%
     dplyr::mutate(CHG = ifelse(AVISITN > 0, AVAL - BASE, NA)) %>%
     dplyr::mutate(PCHG = ifelse(AVISITN > 0, 100 * (CHG / BASE), NA)) %>%
     dplyr::mutate(BASETYPE = "LAST") %>%
@@ -170,22 +170,22 @@ radeg <- function(adsl,
     dplyr::mutate(ATPTN = 1) %>%
     dplyr::mutate(DTYPE = NA) %>%
     var_relabel(
-      STUDYID = attr(ADEG$STUDYID, "label"),
-      USUBJID = attr(ADEG$USUBJID, "label")
+      STUDYID = attr(adeg$STUDYID, "label"),
+      USUBJID = attr(adeg$USUBJID, "label")
     )
 
-  ADEG$ANRIND <- factor(ADEG$ANRIND, levels = c("LOW", "NORMAL", "HIGH"))
-  ADEG$BNRIND <- factor(ADEG$BNRIND, levels = c("LOW", "NORMAL", "HIGH"))
+  adeg$ANRIND <- factor(adeg$ANRIND, levels = c("LOW", "NORMAL", "HIGH"))
+  adeg$BNRIND <- factor(adeg$BNRIND, levels = c("LOW", "NORMAL", "HIGH"))
 
-  ADEG <- var_relabel(
-    ADEG,
+  adeg <- var_relabel(
+    adeg,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
 
   # merge ADSL to be able to add EG date and study day variables
-  ADEG <- dplyr::inner_join(
-    ADEG,
+  adeg <- dplyr::inner_join(
+    adeg,
     adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
@@ -196,7 +196,7 @@ radeg <- function(adsl,
     ))) %>%
     dplyr::ungroup()
 
-  ADEG <- ADEG %>%
+  adeg <- adeg %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::arrange(USUBJID, AVISITN) %>%
     dplyr::mutate(ADTM = rep(
@@ -211,7 +211,7 @@ radeg <- function(adsl,
     dplyr::select(-TRTENDT) %>%
     dplyr::arrange(STUDYID, USUBJID, ADTM)
 
-  ADEG <- ADEG %>%
+  adeg <- adeg %>%
     dplyr::mutate(ASPID = sample(seq_len(dplyr::n()))) %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(EGSEQ = seq_len(dplyr::n())) %>%
@@ -230,21 +230,21 @@ radeg <- function(adsl,
       ASPID
     )
 
-  ADEG <- ADEG %>% dplyr::mutate(ONTRTFL = factor(dplyr::case_when(
+  adeg <- adeg %>% dplyr::mutate(ONTRTFL = factor(dplyr::case_when(
     !AVISIT %in% c("SCREENING", "BASELINE") ~ "Y",
     TRUE ~ ""
   )))
 
-  ADEG <- ADEG %>% dplyr::mutate(AVALC = ifelse(
+  adeg <- adeg %>% dplyr::mutate(AVALC = ifelse(
     PARAMCD == "ECGINTP",
-    as.character(sample_fct(c("ABNORMAL", "NORMAL"), nrow(ADEG), prob = c(0.25, 0.75))),
+    as.character(sample_fct(c("ABNORMAL", "NORMAL"), nrow(adeg), prob = c(0.25, 0.75))),
     as.character(AVAL)
   ))
 
   # Temporarily creating a row_check column to easily match newly created
   # observations with their row correct arrangement.
-  ADEG <- ADEG %>%
-    dplyr::mutate(row_check = seq_len(nrow(ADEG)))
+  adeg <- adeg %>%
+    dplyr::mutate(row_check = seq_len(nrow(adeg)))
 
   # Created function to add in new observations for DTYPE, "MINIMUM" & "MAXIMUM" in this case.
   get_groups <- function(data,
@@ -272,14 +272,14 @@ radeg <- function(adsl,
   }
 
   # Binding the new observations to the dataset from the function above and rearranging in the correct order.
-  ADEG <- rbind(ADEG, get_groups(ADEG, TRUE), get_groups(ADEG, FALSE)) %>%
+  adeg <- rbind(adeg, get_groups(adeg, TRUE), get_groups(adeg, FALSE)) %>%
     dplyr::arrange(row_check) %>%
     dplyr::group_by(USUBJID, PARAMCD, BASETYPE) %>%
     dplyr::arrange(AVISIT, .by_group = TRUE) %>%
     dplyr::ungroup()
 
   # Dropping the "row_check" column created above.
-  ADEG <- ADEG[, -which(names(ADEG) %in% c("row_check"))]
+  adeg <- adeg[, -which(names(adeg) %in% c("row_check"))]
 
   # Created function to easily match rows which comply to ONTRTFL derivation
   flag_variables <- function(data, worst_obs) {
@@ -338,17 +338,17 @@ radeg <- function(adsl,
     return(data_compare)
   }
 
-  ADEG <- flag_variables(ADEG, FALSE) %>% dplyr::rename(WORS01FL = "new_var")
-  ADEG <- flag_variables(ADEG, TRUE) %>% dplyr::rename(WORS02FL = "new_var")
+  adeg <- flag_variables(adeg, FALSE) %>% dplyr::rename(WORS01FL = "new_var")
+  adeg <- flag_variables(adeg, TRUE) %>% dplyr::rename(WORS02FL = "new_var")
 
-  ADEG <- ADEG %>% dplyr::mutate(ANL01FL = factor(ifelse(
+  adeg <- adeg %>% dplyr::mutate(ANL01FL = factor(ifelse(
     (ABLFL == "Y" | (is.na(DTYPE) & WORS01FL == "Y")) &
       (AVISIT != "SCREENING"),
     "Y",
     ""
   )))
 
-  ADEG <- ADEG %>%
+  adeg <- adeg %>%
     dplyr::group_by(USUBJID, PARAMCD, BASETYPE) %>%
     dplyr::mutate(BASEC = ifelse(
       PARAMCD == "ECGINTP",
@@ -368,11 +368,11 @@ radeg <- function(adsl,
     dplyr::ungroup()
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADEG <- mutate_na(ds = ADEG, na_vars = na_vars, na_percentage = na_percentage)
+    adeg <- mutate_na(ds = adeg, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # apply metadata
-  ADEG <- apply_metadata(ADEG, "metadata/ADEG.yml")
+  adeg <- apply_metadata(adeg, "metadata/adeg.yml")
 
-  return(ADEG)
+  return(adeg)
 }

--- a/R/radex.R
+++ b/R/radex.R
@@ -322,7 +322,7 @@ radex <- function(adsl,
   }
 
   # apply metadata
-  adex <- apply_metadata(adex, "metadata/adex.yml")
+  adex <- apply_metadata(adex, "metadata/ADEX.yml")
 }
 
 # Equivalent of stringr::str_extract_all()

--- a/R/radex.R
+++ b/R/radex.R
@@ -22,11 +22,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
+#' adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 #'
-#' ADEX <- radex(ADSL, seed = 2)
+#' ADEX <- radex(adsl, seed = 2)
 #' ADEX
-radex <- function(ADSL,
+radex <- function(adsl,
                   param = c(
                     "Dose administered during constant dosing interval",
                     "Number of doses administered during constant dosing interval",
@@ -51,7 +51,7 @@ radex <- function(ADSL,
     return(get_cached_data("cadex"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(param, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramcd, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(parcat1, min.len = 1, any.missing = FALSE)
@@ -72,11 +72,11 @@ radex <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   ADEX <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PARAM = c(
       rep(
         param_init_list$relvar1[1],
@@ -221,7 +221,7 @@ radex <- function(ADSL,
   )
 
   # merge ADSL to be able to add ADEX date and study day variables
-  ADEX <- dplyr::inner_join(ADEX, ADSL, by = c("STUDYID", "USUBJID")) %>%
+  ADEX <- dplyr::inner_join(ADEX, adsl, by = c("STUDYID", "USUBJID")) %>%
     dplyr::rowwise() %>%
     dplyr::mutate(TRTENDT = lubridate::date(dplyr::case_when(
       is.na(TRTEDTM) ~ lubridate::floor_date(lubridate::date(TRTSDTM) + study_duration_secs, unit = "day"),

--- a/R/radhy.R
+++ b/R/radhy.R
@@ -20,11 +20,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADHY <- radhy(ADSL, seed = 2)
+#' ADHY <- radhy(adsl, seed = 2)
 #' ADHY
-radhy <- function(ADSL,
+radhy <- function(adsl,
                   param = c(
                     "TBILI <= 2 times ULN and ALT value category",
                     "TBILI > 2 times ULN and AST value category",
@@ -81,7 +81,7 @@ radhy <- function(ADSL,
     return(get_cached_data("cadhy"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(param, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramcd, min.len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
@@ -92,12 +92,12 @@ radhy <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   # create all combinations of unique values in STUDYID, USUBJID, PARAM, AVISIT
   ADHY <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
     AVISIT = as.factor(c("BASELINE", "POST-BASELINE")),
     APERIODC = as.factor(c("PERIOD 1", "PERIOD 2")),
@@ -170,12 +170,12 @@ radhy <- function(ADSL,
 
   ADHY <- ADHY %>%
     var_relabel(
-      STUDYID = attr(ADSL$STUDYID, "label"),
-      USUBJID = attr(ADSL$USUBJID, "label")
+      STUDYID = attr(adsl$STUDYID, "label"),
+      USUBJID = attr(adsl$USUBJID, "label")
     )
 
   # merge ADSL to be able to add analysis datetime and analysis relative day variables
-  ADHY <- dplyr::inner_join(ADHY, ADSL, by = c("STUDYID", "USUBJID"))
+  ADHY <- dplyr::inner_join(ADHY, adsl, by = c("STUDYID", "USUBJID"))
 
   # define a simple helper function to create ADY variable
   add_ady <- function(x, avisit) {
@@ -210,7 +210,7 @@ radhy <- function(ADSL,
   # order columns and arrange rows; column order follows ADaM_1.1 specification
   ADHY <-
     ADHY[, c(
-      colnames(ADSL),
+      colnames(adsl),
       "PARAM",
       "PARAMCD",
       "AVAL",

--- a/R/radhy.R
+++ b/R/radhy.R
@@ -240,7 +240,7 @@ radhy <- function(adsl,
     )
 
   # apply metadata
-  adhy <- apply_metadata(adhy, "metadata/adhy.yml")
+  adhy <- apply_metadata(adhy, "metadata/ADHY.yml")
 
   return(adhy)
 }

--- a/R/radlb.R
+++ b/R/radlb.R
@@ -22,14 +22,14 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADLB <- radlb(ADSL, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+#' ADLB <- radlb(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
 #' ADLB
 #'
-#' ADLB <- radlb(ADSL, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
+#' ADLB <- radlb(adsl, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
 #' ADLB
-radlb <- function(ADSL,
+radlb <- function(adsl,
                   lbcat = c("CHEMISTRY", "CHEMISTRY", "IMMUNOLOGY"),
                   param = c(
                     "Alanine Aminotransferase Measurement",
@@ -57,7 +57,7 @@ radlb <- function(ADSL,
     return(get_cached_data("cadlb"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(param, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramcd, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramu, min.len = 1, any.missing = FALSE)
@@ -79,11 +79,11 @@ radlb <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   ADLB <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
     AVISIT = visit_schedule(visit_format = visit_format, n_assessments = n_assessments, n_days = n_days),
     stringsAsFactors = FALSE
@@ -139,7 +139,7 @@ radlb <- function(ADSL,
   ADLB <- ADLB[order(ADLB$STUDYID, ADLB$USUBJID, ADLB$PARAMCD, ADLB$AVISITN), ]
 
   ADLB <- Reduce(rbind, lapply(split(ADLB, ADLB$USUBJID), function(x) {
-    x$STUDYID <- ADSL$STUDYID[which(ADSL$USUBJID == x$USUBJID[1])]
+    x$STUDYID <- adsl$STUDYID[which(adsl$USUBJID == x$USUBJID[1])]
     x$ABLFL2 <- ifelse(x$AVISIT == "SCREENING", "Y", "")
     x$ABLFL <- ifelse(toupper(visit_format) == "WEEK" & x$AVISIT == "BASELINE",
       "Y",
@@ -262,8 +262,8 @@ radlb <- function(ADSL,
       ATOXGR == "-4" ~ "<Missing>",
     ))) %>%
     var_relabel(
-      STUDYID = attr(ADSL$STUDYID, "label"),
-      USUBJID = attr(ADSL$USUBJID, "label")
+      STUDYID = attr(adsl$STUDYID, "label"),
+      USUBJID = attr(adsl$USUBJID, "label")
     )
 
   # High and low descriptions of the different PARAMCD values
@@ -304,7 +304,7 @@ radlb <- function(ADSL,
   # merge ADSL to be able to add LB date and study day variables
   ADLB <- dplyr::inner_join(
     ADLB,
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::rowwise() %>%

--- a/R/radlb.R
+++ b/R/radlb.R
@@ -24,11 +24,11 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADLB <- radlb(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
-#' ADLB
+#' adlb <- radlb(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+#' adlb
 #'
-#' ADLB <- radlb(adsl, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
-#' ADLB
+#' adlb <- radlb(adsl, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
+#' adlb
 radlb <- function(adsl,
                   lbcat = c("CHEMISTRY", "CHEMISTRY", "IMMUNOLOGY"),
                   param = c(
@@ -81,7 +81,7 @@ radlb <- function(adsl,
   }
   study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
-  ADLB <- expand.grid(
+  adlb <- expand.grid(
     STUDYID = unique(adsl$STUDYID),
     USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
@@ -90,44 +90,44 @@ radlb <- function(adsl,
   )
 
   # assign AVAL based on different tests
-  ADLB <- ADLB %>% mutate(AVAL = case_when(
-    PARAM == param[1] ~ stats::rnorm(nrow(ADLB), mean = aval_mean[1], sd = 10),
-    PARAM == param[2] ~ stats::rnorm(nrow(ADLB), mean = aval_mean[2], sd = 1),
-    PARAM == param[3] ~ stats::rnorm(nrow(ADLB), mean = aval_mean[3], sd = 0.1)
+  adlb <- adlb %>% mutate(AVAL = case_when(
+    PARAM == param[1] ~ stats::rnorm(nrow(adlb), mean = aval_mean[1], sd = 10),
+    PARAM == param[2] ~ stats::rnorm(nrow(adlb), mean = aval_mean[2], sd = 1),
+    PARAM == param[3] ~ stats::rnorm(nrow(adlb), mean = aval_mean[3], sd = 0.1)
   ))
 
   # assign related variable values: PARAMxLBCAT are related
-  ADLB <- ADLB %>% rel_var(
+  adlb <- adlb %>% rel_var(
     var_name = "LBCAT",
     related_var = "PARAM",
     var_values = lbcat_init_list$relvar2
   )
 
   # assign related variable values: PARAMxPARAMCD are related
-  ADLB <- ADLB %>% rel_var(
+  adlb <- adlb %>% rel_var(
     var_name = "PARAMCD",
     related_var = "PARAM",
     var_values = param_init_list$relvar2
   )
 
-  ADLB <- ADLB %>%
+  adlb <- adlb %>%
     dplyr::mutate(LBTESTCD = PARAMCD) %>%
     dplyr::mutate(LBTEST = PARAM)
 
-  ADLB <- ADLB %>% dplyr::mutate(AVISITN = dplyr::case_when(
+  adlb <- adlb %>% dplyr::mutate(AVISITN = dplyr::case_when(
     AVISIT == "SCREENING" ~ -1,
     AVISIT == "BASELINE" ~ 0,
     (grepl("^WEEK", AVISIT) | grepl("^CYCLE", AVISIT)) ~ as.numeric(AVISIT) - 2,
     TRUE ~ NA_real_
   ))
 
-  ADLB <- ADLB %>% rel_var(
+  adlb <- adlb %>% rel_var(
     var_name = "AVALU",
     related_var = "PARAM",
     var_values = unit_init_list$relvar2
   )
 
-  ADLB <- ADLB %>%
+  adlb <- adlb %>%
     dplyr::mutate(AVISITN = dplyr::case_when(
       AVISIT == "SCREENING" ~ -1,
       AVISIT == "BASELINE" ~ 0,
@@ -136,9 +136,9 @@ radlb <- function(adsl,
     ))
 
   # order to prepare for change from screening and baseline values
-  ADLB <- ADLB[order(ADLB$STUDYID, ADLB$USUBJID, ADLB$PARAMCD, ADLB$AVISITN), ]
+  adlb <- adlb[order(adlb$STUDYID, adlb$USUBJID, adlb$PARAMCD, adlb$AVISITN), ]
 
-  ADLB <- Reduce(rbind, lapply(split(ADLB, ADLB$USUBJID), function(x) {
+  adlb <- Reduce(rbind, lapply(split(adlb, adlb$USUBJID), function(x) {
     x$STUDYID <- adsl$STUDYID[which(adsl$USUBJID == x$USUBJID[1])]
     x$ABLFL2 <- ifelse(x$AVISIT == "SCREENING", "Y", "")
     x$ABLFL <- ifelse(toupper(visit_format) == "WEEK" & x$AVISIT == "BASELINE",
@@ -148,10 +148,10 @@ radlb <- function(adsl,
     x
   }))
 
-  ADLB$BASE2 <- retain(ADLB, ADLB$AVAL, ADLB$ABLFL2 == "Y")
-  ADLB$BASE <- ifelse(ADLB$ABLFL2 != "Y", retain(ADLB, ADLB$AVAL, ADLB$ABLFL == "Y"), NA)
+  adlb$BASE2 <- retain(adlb, adlb$AVAL, adlb$ABLFL2 == "Y")
+  adlb$BASE <- ifelse(adlb$ABLFL2 != "Y", retain(adlb, adlb$AVAL, adlb$ABLFL == "Y"), NA)
 
-  ADLB <- ADLB %>%
+  adlb <- adlb %>%
     dplyr::mutate(CHG2 = AVAL - BASE2) %>%
     dplyr::mutate(PCHG2 = 100 * (CHG2 / BASE2)) %>%
     dplyr::mutate(CHG = AVAL - BASE) %>%
@@ -189,7 +189,7 @@ radlb <- function(adsl,
       AVISITN > 0,
       paste(
         retain(
-          ADLB, as.character(BNRIND),
+          adlb, as.character(BNRIND),
           AVISITN == 0
         ),
         ANRIND,
@@ -200,13 +200,13 @@ radlb <- function(adsl,
     dplyr::mutate(ATOXGR = factor(dplyr::case_when(
       ANRIND == "LOW" ~ sample(
         c("-1", "-2", "-3", "-4", "-5"),
-        nrow(ADLB),
+        nrow(adlb),
         replace = TRUE,
         prob = c(0.30, 0.25, 0.20, 0.15, 0)
       ),
       ANRIND == "HIGH" ~ sample(
         c("1", "2", "3", "4", "5"),
-        nrow(ADLB),
+        nrow(adlb),
         replace = TRUE,
         prob = c(0.30, 0.25, 0.20, 0.15, 0)
       ),
@@ -292,18 +292,18 @@ radlb <- function(adsl,
     "WBC", "White blood cell decreased", "Leukocytosis",
   )
 
-  # merge grade_lookup onto ADLB
-  ADLB <- dplyr::left_join(ADLB, grade_lookup, by = "PARAMCD")
+  # merge grade_lookup onto adlb
+  adlb <- dplyr::left_join(adlb, grade_lookup, by = "PARAMCD")
 
-  ADLB <- var_relabel(
-    ADLB,
+  adlb <- var_relabel(
+    adlb,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
 
   # merge ADSL to be able to add LB date and study day variables
-  ADLB <- dplyr::inner_join(
-    ADLB,
+  adlb <- dplyr::inner_join(
+    adlb,
     adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
@@ -314,7 +314,7 @@ radlb <- function(adsl,
     ))) %>%
     dplyr::ungroup()
 
-  ADLB <- ADLB %>%
+  adlb <- adlb %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::arrange(USUBJID, AVISITN) %>%
     dplyr::mutate(ADTM = rep(
@@ -329,7 +329,7 @@ radlb <- function(adsl,
     dplyr::select(-TRTENDT) %>%
     dplyr::arrange(STUDYID, USUBJID, ADTM)
 
-  ADLB <- ADLB %>%
+  adlb <- adlb %>%
     dplyr::mutate(ASPID = sample(seq_len(dplyr::n()))) %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(LBSEQ = seq_len(dplyr::n())) %>%
@@ -348,7 +348,7 @@ radlb <- function(adsl,
       ASPID
     )
 
-  ADLB <- ADLB %>% dplyr::mutate(ONTRTFL = factor(dplyr::case_when(
+  adlb <- adlb %>% dplyr::mutate(ONTRTFL = factor(dplyr::case_when(
     !AVISIT %in% c("SCREENING", "BASELINE") ~ "Y",
     TRUE ~ ""
   )))
@@ -410,13 +410,13 @@ radlb <- function(adsl,
     return(data_compare)
   }
 
-  ADLB <- flag_variables(ADLB, TRUE, "ELSE", FALSE) %>% dplyr::rename(WORS01FL = "new_var")
-  ADLB <- flag_variables(ADLB, FALSE, TRUE, TRUE) %>% dplyr::rename(WGRHIFL = "new_var")
-  ADLB <- flag_variables(ADLB, FALSE, FALSE, TRUE) %>% dplyr::rename(WGRLOFL = "new_var")
-  ADLB <- flag_variables(ADLB, TRUE, TRUE, TRUE) %>% dplyr::rename(WGRHIVFL = "new_var")
-  ADLB <- flag_variables(ADLB, TRUE, FALSE, TRUE) %>% dplyr::rename(WGRLOVFL = "new_var")
+  adlb <- flag_variables(adlb, TRUE, "ELSE", FALSE) %>% dplyr::rename(WORS01FL = "new_var")
+  adlb <- flag_variables(adlb, FALSE, TRUE, TRUE) %>% dplyr::rename(WGRHIFL = "new_var")
+  adlb <- flag_variables(adlb, FALSE, FALSE, TRUE) %>% dplyr::rename(WGRLOFL = "new_var")
+  adlb <- flag_variables(adlb, TRUE, TRUE, TRUE) %>% dplyr::rename(WGRHIVFL = "new_var")
+  adlb <- flag_variables(adlb, TRUE, FALSE, TRUE) %>% dplyr::rename(WGRLOVFL = "new_var")
 
-  ADLB <- ADLB %>% dplyr::mutate(ANL01FL = ifelse(
+  adlb <- adlb %>% dplyr::mutate(ANL01FL = ifelse(
     (ABLFL == "Y" | (WORS01FL == "Y" & is.na(DTYPE))) &
       (AVISIT != "SCREENING"),
     "Y",
@@ -424,12 +424,12 @@ radlb <- function(adsl,
   ))
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADLB <- mutate_na(ds = ADLB, na_vars = na_vars, na_percentage = na_percentage)
+    adlb <- mutate_na(ds = adlb, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # apply metadata
 
-  ADLB <- apply_metadata(ADLB, "metadata/ADLB.yml")
+  adlb <- apply_metadata(adlb, "metadata/adlb.yml")
 
-  return(ADLB)
+  return(adlb)
 }

--- a/R/radlb.R
+++ b/R/radlb.R
@@ -429,7 +429,7 @@ radlb <- function(adsl,
 
   # apply metadata
 
-  adlb <- apply_metadata(adlb, "metadata/adlb.yml")
+  adlb <- apply_metadata(adlb, "metadata/ADLB.yml")
 
   return(adlb)
 }

--- a/R/radmh.R
+++ b/R/radmh.R
@@ -21,8 +21,8 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 #'
-#' ADMH <- radmh(adsl, seed = 2)
-#' ADMH
+#' admh <- radmh(adsl, seed = 2)
+#' admh
 radmh <- function(adsl,
                   max_n_mhs = 10L,
                   lookup = NULL,
@@ -65,7 +65,7 @@ radmh <- function(adsl,
   }
   study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
-  ADMH <- Map(
+  admh <- Map(
     function(id, sid) {
       n_mhs <- sample(0:max_n_mhs, 1)
       i <- sample(seq_len(nrow(lookup_mh)), n_mhs, TRUE)
@@ -82,15 +82,15 @@ radmh <- function(adsl,
     `[`(c(4, 5, 1, 2, 3)) %>%
     dplyr::mutate(MHTERM = MHDECOD)
 
-  ADMH <- var_relabel(
-    ADMH,
+  admh <- var_relabel(
+    admh,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
 
   # merge ADSL to be able to add MH date and study day variables
-  ADMH <- dplyr::inner_join(
-    ADMH,
+  admh <- dplyr::inner_join(
+    admh,
     adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
@@ -124,7 +124,7 @@ radmh <- function(adsl,
       (AENDTM >= TRTSDTM | (is.na(AENDTM) & grepl("Ongoing", MHDISTAT))) ~ "PRIOR_CONCOMITANT"
     ))
 
-  ADMH <- ADMH %>%
+  admh <- admh %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(MHSEQ = seq_len(dplyr::n())) %>%
     dplyr::mutate(ASEQ = MHSEQ) %>%
@@ -132,11 +132,11 @@ radmh <- function(adsl,
     dplyr::arrange(STUDYID, USUBJID, ASTDTM, MHSEQ)
 
   if (length(na_vars) > 0 && na_percentage > 0 && na_percentage <= 1) {
-    ADMH <- mutate_na(ds = ADMH, na_vars = na_vars, na_percentage = na_percentage)
+    admh <- mutate_na(ds = admh, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # apply metadata
-  ADMH <- apply_metadata(ADMH, "metadata/ADMH.yml")
+  admh <- apply_metadata(admh, "metadata/admh.yml")
 
-  return(ADMH)
+  return(admh)
 }

--- a/R/radmh.R
+++ b/R/radmh.R
@@ -19,11 +19,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
+#' adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 #'
-#' ADMH <- radmh(ADSL, seed = 2)
+#' ADMH <- radmh(adsl, seed = 2)
 #' ADMH
-radmh <- function(ADSL,
+radmh <- function(adsl,
                   max_n_mhs = 10L,
                   lookup = NULL,
                   seed = NULL,
@@ -35,7 +35,7 @@ radmh <- function(ADSL,
     return(get_cached_data("cadmh"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_integer(max_n_mhs, len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
   checkmate::assert_number(na_percentage, lower = 0, upper = 1)
@@ -63,7 +63,7 @@ radmh <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   ADMH <- Map(
     function(id, sid) {
@@ -75,8 +75,8 @@ radmh <- function(ADSL,
         STUDYID = sid
       )
     },
-    ADSL$USUBJID,
-    ADSL$STUDYID
+    adsl$USUBJID,
+    adsl$STUDYID
   ) %>%
     Reduce(rbind, .) %>%
     `[`(c(4, 5, 1, 2, 3)) %>%
@@ -91,7 +91,7 @@ radmh <- function(ADSL,
   # merge ADSL to be able to add MH date and study day variables
   ADMH <- dplyr::inner_join(
     ADMH,
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::rowwise() %>%

--- a/R/radmh.R
+++ b/R/radmh.R
@@ -136,7 +136,7 @@ radmh <- function(adsl,
   }
 
   # apply metadata
-  admh <- apply_metadata(admh, "metadata/admh.yml")
+  admh <- apply_metadata(admh, "metadata/ADMH.yml")
 
   return(admh)
 }

--- a/R/radpc.R
+++ b/R/radpc.R
@@ -124,5 +124,5 @@ radpc <- function(adsl,
     adpc <- mutate_na(ds = adpc, na_vars = na_vars, na_percentage = na_percentage)
   }
 
-  adpc <- apply_metadata(adpc, "metadata/adpc.yml")
+  adpc <- apply_metadata(adpc, "metadata/ADPC.yml")
 }

--- a/R/radpc.R
+++ b/R/radpc.R
@@ -19,14 +19,14 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADPC <- radpc(ADSL, seed = 2)
+#' ADPC <- radpc(adsl, seed = 2)
 #' ADPC
 #'
-#' ADPC <- radpc(ADSL, seed = 2, duration = 3)
+#' ADPC <- radpc(adsl, seed = 2, duration = 3)
 #' ADPC
-radpc <- function(ADSL,
+radpc <- function(adsl,
                   avalu = "ug/mL",
                   constants = c(D = 100, ka = 0.8, ke = 1),
                   duration = 2,
@@ -41,7 +41,7 @@ radpc <- function(ADSL,
     return(get_cached_data("cadpc"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(avalu, len = 1, any.missing = FALSE)
   checkmate::assert_subset(names(constants), c("D", "ka", "ke"))
   checkmate::assert_numeric(x = duration, max.len = 1)
@@ -57,12 +57,12 @@ radpc <- function(ADSL,
   radpc_core <- function(day) {
     adpc_day <- tidyr::expand_grid(
       data.frame(
-        STUDYID = ADSL$STUDYID,
-        USUBJID = ADSL$USUBJID,
-        ARMCD = ADSL$ARMCD,
+        STUDYID = adsl$STUDYID,
+        USUBJID = adsl$USUBJID,
+        ARMCD = adsl$ARMCD,
         A0 = unname(constants["D"]),
-        ka = unname(constants["ka"]) - stats::runif(length(ADSL$USUBJID), -0.2, 0.2),
-        ke = unname(constants["ke"]) - stats::runif(length(ADSL$USUBJID), -0.2, 0.2)
+        ka = unname(constants["ka"]) - stats::runif(length(adsl$USUBJID), -0.2, 0.2),
+        ke = unname(constants["ke"]) - stats::runif(length(adsl$USUBJID), -0.2, 0.2)
       ),
       PCTPTNUM = if (day == 1) c(0, 0.5, 1, 1.5, 2, 3, 4, 8, 12) else 24 * (day - 1),
       PARAM = factor(c("Plasma Drug X", "Urine Drug X", "Plasma Drug Y", "Urine Drug Y"))
@@ -117,7 +117,7 @@ radpc <- function(ADSL,
 
   ADPC <- do.call(rbind, ADPC)
 
-  ADPC <- dplyr::inner_join(ADPC, ADSL, by = c("STUDYID", "USUBJID", "ARMCD")) %>%
+  ADPC <- dplyr::inner_join(ADPC, adsl, by = c("STUDYID", "USUBJID", "ARMCD")) %>%
     dplyr::filter(ACTARM != "B: Placebo", !(ACTARM == "A: Drug X" & PARAM == "Plasma Drug Y"))
 
   if (length(na_vars) > 0 && na_percentage > 0) {

--- a/R/radpc.R
+++ b/R/radpc.R
@@ -21,11 +21,11 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADPC <- radpc(adsl, seed = 2)
-#' ADPC
+#' adpc <- radpc(adsl, seed = 2)
+#' adpc
 #'
-#' ADPC <- radpc(adsl, seed = 2, duration = 3)
-#' ADPC
+#' adpc <- radpc(adsl, seed = 2, duration = 3)
+#' adpc
 radpc <- function(adsl,
                   avalu = "ug/mL",
                   constants = c(D = 100, ka = 0.8, ke = 1),
@@ -109,20 +109,20 @@ radpc <- function(adsl,
     return(adpc_day)
   }
 
-  ADPC <- list()
+  adpc <- list()
 
   for (day in seq(duration)[seq(duration) <= 7 | ((seq(duration) - 1) %% 7 == 0)]) {
-    ADPC[[day]] <- radpc_core(day = day)
+    adpc[[day]] <- radpc_core(day = day)
   }
 
-  ADPC <- do.call(rbind, ADPC)
+  adpc <- do.call(rbind, adpc)
 
-  ADPC <- dplyr::inner_join(ADPC, adsl, by = c("STUDYID", "USUBJID", "ARMCD")) %>%
+  adpc <- dplyr::inner_join(adpc, adsl, by = c("STUDYID", "USUBJID", "ARMCD")) %>%
     dplyr::filter(ACTARM != "B: Placebo", !(ACTARM == "A: Drug X" & PARAM == "Plasma Drug Y"))
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADPC <- mutate_na(ds = ADPC, na_vars = na_vars, na_percentage = na_percentage)
+    adpc <- mutate_na(ds = adpc, na_vars = na_vars, na_percentage = na_percentage)
   }
 
-  ADPC <- apply_metadata(ADPC, "metadata/ADPC.yml")
+  adpc <- apply_metadata(adpc, "metadata/adpc.yml")
 }

--- a/R/radpp.R
+++ b/R/radpp.R
@@ -129,13 +129,13 @@ radpp <- function(adsl,
   adpp <- adpp %>% dplyr::mutate(REGIMEN = "BID")
 
   # derive PPSTINT and PPENINT based on PARAMCD
-  T1_T2 <- data.frame(
+  t1_t2 <- data.frame(
     PARAMCD = c("RCAMINT", "RCAMINT", "RCPCINT", "RCPCINT"),
     PPSTINT = c("P0H", "P0H", "P0H", "P0H"),
     PPENINT = c("P12H", "P24H", "P12H", "P24H")
   )
   adpp <- adpp %>%
-    dplyr::left_join(T1_T2, by = c("PARAMCD"), multiple = "all")
+    dplyr::left_join(t1_t2, by = c("PARAMCD"), multiple = "all")
 
   adpp <- dplyr::inner_join(adpp, adsl, by = c("STUDYID", "USUBJID")) %>%
     dplyr::filter(ACTARM != "B: Placebo", !(ACTARM == "A: Drug X" &

--- a/R/radpp.R
+++ b/R/radpp.R
@@ -18,11 +18,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADPP <- radpp(ADSL, seed = 2)
+#' ADPP <- radpp(adsl, seed = 2)
 #' ADPP
-radpp <- function(ADSL,
+radpp <- function(adsl,
                   ppcat = c("Plasma Drug X", "Plasma Drug Y", "Metabolite Drug X", "Metabolite Drug Y"),
                   ppspec = c(
                     "Plasma", "Plasma", "Plasma", "Matrix of PD", "Matrix of PD",
@@ -80,8 +80,8 @@ radpp <- function(ADSL,
   unit_init_list <- relvar_init(param, paramu)
 
   ADPP <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PPCAT = as.factor(ppcat),
     PARAM = as.factor(param_init_list$relvar1),
     AVISIT = visit_schedule(visit_format = visit_format, n_assessments = 1L, n_days = n_days),
@@ -137,7 +137,7 @@ radpp <- function(ADSL,
   ADPP <- ADPP %>%
     dplyr::left_join(T1_T2, by = c("PARAMCD"), multiple = "all")
 
-  ADPP <- dplyr::inner_join(ADPP, ADSL, by = c("STUDYID", "USUBJID")) %>%
+  ADPP <- dplyr::inner_join(ADPP, adsl, by = c("STUDYID", "USUBJID")) %>%
     dplyr::filter(ACTARM != "B: Placebo", !(ACTARM == "A: Drug X" &
       (PPCAT == "Plasma Drug Y" | PPCAT == "Metabolite Drug Y")))
 

--- a/R/radpp.R
+++ b/R/radpp.R
@@ -152,6 +152,6 @@ radpp <- function(adsl,
     adpp <- mutate_na(ds = adpp, na_vars = na_vars, na_percentage = na_percentage)
   }
 
-  adpp <- apply_metadata(adpp, "metadata/adpp.yml")
+  adpp <- apply_metadata(adpp, "metadata/ADPP.yml")
   return(adpp)
 }

--- a/R/radqlqc.R
+++ b/R/radqlqc.R
@@ -251,7 +251,7 @@ radqlqc <- function(adsl,
       QSTESTCD
     )
   # apply metadata
-  adqlqc_final <- apply_metadata(adqlqc_final, "metadata/adqlqc.yml")
+  adqlqc_final <- apply_metadata(adqlqc_final, "metadata/ADQLQC.yml")
   return(adqlqc_final)
 }
 

--- a/R/radqlqc.R
+++ b/R/radqlqc.R
@@ -22,8 +22,8 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 #'
-#' ADQLQC <- radqlqc(adsl, seed = 1, percent = 80, number = 2)
-#' ADQLQC
+#' adqlqc <- radqlqc(adsl, seed = 1, percent = 80, number = 2)
+#' adqlqc
 radqlqc <- function(adsl,
                     percent,
                     number,
@@ -43,9 +43,9 @@ radqlqc <- function(adsl,
   }
 
   # ADQLQC data -------------------------------------------------------------
-  QS <- get_qs_data(adsl, n_assessments = 5L, seed = seed, na_percentage = 0.1)
-  # prepare ADaM adqlqc data
-  adqlqc1 <- prep_adqlqc(df = QS)
+  qs <- get_qs_data(adsl, n_assessments = 5L, seed = seed, na_percentage = 0.1)
+  # prepare ADaM ADQLQC data
+  adqlqc1 <- prep_adqlqc(df = qs)
   # derive AVAL and AVALC
   adqlqc1 <- mutate(
     adqlqc1,
@@ -59,14 +59,14 @@ radqlqc <- function(adsl,
     ADTM = QSDTC
   )
   # include scale calculation
-  ADQLQCtmp <- calc_scales(adqlqc1)
+  adqlqc_tmp <- calc_scales(adqlqc1)
   # order to prepare for change from screening and baseline values
-  ADQLQCtmp <- ADQLQCtmp[order(ADQLQCtmp$STUDYID, ADQLQCtmp$USUBJID, ADQLQCtmp$PARAMCD, ADQLQCtmp$AVISITN), ]
+  adqlqc_tmp <- adqlqc_tmp[order(adqlqc_tmp$STUDYID, adqlqc_tmp$USUBJID, adqlqc_tmp$PARAMCD, adqlqc_tmp$AVISITN), ]
 
-  ADQLQCtmp <- Reduce(
+  adqlqc_tmp <- Reduce(
     rbind,
     lapply(
-      split(ADQLQCtmp, ADQLQCtmp$USUBJID),
+      split(adqlqc_tmp, adqlqc_tmp$USUBJID),
       function(x) {
         x$STUDYID <- adsl$STUDYID[which(adsl$USUBJID == x$USUBJID[1])]
         x$ABLFL2 <- ifelse(x$AVISIT == "SCREENING", "Y", "")
@@ -86,28 +86,28 @@ radqlqc <- function(adsl,
     )
   )
 
-  ADQLQCtmp$BASE2 <- ifelse(
-    str_detect(ADQLQCtmp$PARCAT2, "Completion", negate = TRUE),
+  adqlqc_tmp$BASE2 <- ifelse(
+    str_detect(adqlqc_tmp$PARCAT2, "Completion", negate = TRUE),
     retain(
-      df = ADQLQCtmp,
-      value_var = ADQLQCtmp$AVAL,
-      event = ADQLQCtmp$ABLFL2 == "Y"
+      df = adqlqc_tmp,
+      value_var = adqlqc_tmp$AVAL,
+      event = adqlqc_tmp$ABLFL2 == "Y"
     ),
     NA
   )
 
-  ADQLQCtmp$BASE <- ifelse(
-    ADQLQCtmp$ABLFL2 != "Y" &
-      str_detect(ADQLQCtmp$PARCAT2, "Completion", negate = TRUE),
+  adqlqc_tmp$BASE <- ifelse(
+    adqlqc_tmp$ABLFL2 != "Y" &
+      str_detect(adqlqc_tmp$PARCAT2, "Completion", negate = TRUE),
     retain(
-      ADQLQCtmp,
-      ADQLQCtmp$AVAL,
-      ADQLQCtmp$ABLFL == "Y"
+      adqlqc_tmp,
+      adqlqc_tmp$AVAL,
+      adqlqc_tmp$ABLFL == "Y"
     ),
     NA
   )
 
-  ADQLQCtmp <- ADQLQCtmp %>%
+  adqlqc_tmp <- adqlqc_tmp %>%
     dplyr::mutate(CHG2 = AVAL - BASE2) %>%
     dplyr::mutate(PCHG2 = 100 * (CHG2 / BASE2)) %>%
     dplyr::mutate(CHG = AVAL - BASE) %>%
@@ -117,21 +117,21 @@ radqlqc <- function(adsl,
       USUBJID = attr(adsl$USUBJID, "label")
     )
   # derive CHGCAT1 ----------------------------------------------------------
-  ADQLQCtmp <- derv_chgcat1(dataset = ADQLQCtmp)
+  adqlqc_tmp <- derv_chgcat1(dataset = adqlqc_tmp)
 
-  ADQLQCtmp <- var_relabel(
-    ADQLQCtmp,
+  adqlqc_tmp <- var_relabel(
+    adqlqc_tmp,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
 
-  ADQLQCtmp <- arrange(
-    ADQLQCtmp,
+  adqlqc_tmp <- arrange(
+    adqlqc_tmp,
     USUBJID,
     AVISITN
   )
   # Merge ADSL --------------------------------------------------------------
-  # adsl variables needed for ADQLQC
+  # ADSL variables needed for ADQLQC
   adsl_vars <- c(
     "STUDYID", "USUBJID", "SUBJID", "SITEID", "REGION1", "COUNTRY", "ETHNIC", "AGE",
     "AGEU", "AAGE", "AAGEU", "AGEGR1", "AGEGR2", "AGEGR3", "STRATwNM", "STRATw", "STRATwV",
@@ -142,8 +142,8 @@ radqlqc <- function(adsl,
     adsl,
     any_of(adsl_vars)
   )
-  ADQLQC <- dplyr::inner_join(
-    ADQLQCtmp,
+  adqlqc <- dplyr::inner_join(
+    adqlqc_tmp,
     adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
@@ -158,7 +158,7 @@ radqlqc <- function(adsl,
 
   # get compliance data ---------------------------------------------------
   compliance_data <- comp_derv(
-    dataset = ADQLQC,
+    dataset = adqlqc,
     percent = percent,
     number = number
   )
@@ -169,8 +169,8 @@ radqlqc <- function(adsl,
     by = c("STUDYID", "USUBJID")
   )
   # add completion to ADQLQC
-  ADQLQC <- bind_rows(
-    ADQLQC,
+  adqlqc <- bind_rows(
+    adqlqc,
     compliance_data
   ) %>%
     arrange(
@@ -179,8 +179,8 @@ radqlqc <- function(adsl,
       QSTESTCD
     )
   # find first set of questionnaire observations
-  ADQLQC_x <- arrange(
-    ADQLQC,
+  adqlqc_x <- arrange(
+    adqlqc,
     USUBJID,
     ADTM
   ) %>%
@@ -194,9 +194,9 @@ radqlqc <- function(adsl,
     ) %>%
     summarise(first_date = first(ADTM), .groups = "drop")
 
-  ADQLQC <- left_join(
-    ADQLQC,
-    ADQLQC_x,
+  adqlqc <- left_join(
+    adqlqc,
+    adqlqc_x,
     by = c("USUBJID", "ADTM")
   ) %>%
     mutate(
@@ -210,7 +210,7 @@ radqlqc <- function(adsl,
     select(-first_date)
 
   # final dataset -----------------------------------------------------------
-  ADQLQC_final <- ADQLQC %>%
+  adqlqc_final <- adqlqc %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(ASEQ = row_number()) %>%
     dplyr::ungroup() %>%
@@ -236,14 +236,14 @@ radqlqc <- function(adsl,
     "ANL04FL", "CGCAT1NX"
   )
   # order variables in mapped qs by variables in adam_vars
-  adqlqc_name_ordered <- names(ADQLQC_final)[order(match(names(ADQLQC_final), adam_vars))]
+  adqlqc_name_ordered <- names(adqlqc_final)[order(match(names(adqlqc_final), adam_vars))]
   # adqlqc with variables ordered per gdsr
-  ADQLQC_final <- ADQLQC_final %>%
+  adqlqc_final <- adqlqc_final %>%
     select(
       any_of(adqlqc_name_ordered)
     )
 
-  ADQLQC_final <- relocate(ADQLQC_final, "QSEVLINT", .after = "QSTESTCD") %>%
+  adqlqc_final <- relocate(adqlqc_final, "QSEVLINT", .after = "QSTESTCD") %>%
     arrange(
       USUBJID,
       AVISITN,
@@ -251,8 +251,8 @@ radqlqc <- function(adsl,
       QSTESTCD
     )
   # apply metadata
-  ADQLQC_final <- apply_metadata(ADQLQC_final, "metadata/ADQLQC.yml")
-  return(ADQLQC_final)
+  adqlqc_final <- apply_metadata(adqlqc_final, "metadata/adqlqc.yml")
+  return(adqlqc_final)
 }
 
 #' Helper Functions for Constructing ADQLQC
@@ -264,7 +264,7 @@ radqlqc <- function(adsl,
 #'
 #' @examples
 #' adsl <- radsl(N = 10, study_duration = 2, seed = 1)
-#' ADQLQC <- radqlqc(adsl, seed = 1, percent = 80, number = 2)
+#' adqlqc <- radqlqc(adsl, seed = 1, percent = 80, number = 2)
 #'
 #' @name h_adqlqc
 NULL
@@ -277,8 +277,8 @@ NULL
 #' @keywords internal
 #'
 #' @examples
-#' QS <- random.cdisc.data:::get_qs_data(adsl, n_assessments = 5L, seed = 1, na_percentage = 0.1)
-#' QS
+#' qs <- random.cdisc.data:::get_qs_data(adsl, n_assessments = 5L, seed = 1, na_percentage = 0.1)
+#' qs
 get_qs_data <- function(adsl,
                         visit_format = "CYCLE",
                         n_assessments = 5L,
@@ -300,7 +300,7 @@ get_qs_data <- function(adsl,
 
   # get subjects for QS data from ADSL
   # get studyid, subject for QS generation
-  QS <- select(
+  qs <- select(
     adsl,
     STUDYID,
     USUBJID
@@ -331,12 +331,12 @@ get_qs_data <- function(adsl,
 
   checkmate::assert_data_frame(lookup, null.ok = TRUE)
 
-  lookup_QS <- if (!is.null(lookup)) {
+  lookup_qs <- if (!is.null(lookup)) {
     lookup
   } else {
     expand.grid(
-      STUDYID = unique(QS$STUDYID),
-      USUBJID = QS$USUBJID,
+      STUDYID = unique(qs$STUDYID),
+      USUBJID = qs$USUBJID,
       QSTEST = qstest_init_list$relvar1,
       VISIT = visit_schedule(
         visit_format = visit_format,
@@ -348,14 +348,14 @@ get_qs_data <- function(adsl,
   }
 
   # assign related variable values: QSTESTxQSTESTCD are related
-  lookup_QS <- lookup_QS %>% rel_var(
+  lookup_qs <- lookup_qs %>% rel_var(
     var_name = "QSTESTCD",
     related_var = "QSTEST",
     var_values = qstest_init_list$relvar2
   )
 
-  lookup_QS <- left_join(
-    lookup_QS,
+  lookup_qs <- left_join(
+    lookup_qs,
     eortc_qlq_c30_sub,
     by = c(
       "QSTEST",
@@ -364,8 +364,8 @@ get_qs_data <- function(adsl,
     multiple = "all"
   )
 
-  lookup_QS <- dplyr::mutate(
-    lookup_QS,
+  lookup_qs <- dplyr::mutate(
+    lookup_qs,
     VISITNUM = dplyr::case_when(
       VISIT == "SCREENING" ~ -1,
       VISIT == "BASELINE" ~ 0,
@@ -376,11 +376,11 @@ get_qs_data <- function(adsl,
 
   # # prep QSALL --------------------------------------------------------------
   # get last subject and visit for QSALL
-  last_subj_vis <- select(lookup_QS, USUBJID, VISIT) %>%
+  last_subj_vis <- select(lookup_qs, USUBJID, VISIT) %>%
     distinct() %>%
     slice(n())
   last_subj_vis_full <- filter(
-    lookup_QS,
+    lookup_qs,
     USUBJID == last_subj_vis$USUBJID,
     VISIT == last_subj_vis$VISIT
   )
@@ -397,14 +397,14 @@ get_qs_data <- function(adsl,
   )
 
   # remove last subject and visit from main data
-  lookup_QS_sub <- anti_join(
-    lookup_QS,
+  lookup_qs_sub <- anti_join(
+    lookup_qs,
     last_subj_vis_full,
     by = c("USUBJID", "VISIT")
   )
 
   set.seed(seed)
-  lookup_QS_sub_x <- lookup_QS_sub %>%
+  lookup_qs_sub_x <- lookup_qs_sub %>%
     group_by(
       USUBJID,
       QSTESTCD,
@@ -414,8 +414,8 @@ get_qs_data <- function(adsl,
     ungroup() %>%
     as.data.frame()
 
-  lookup_QS_sub_x <- arrange(
-    lookup_QS_sub_x,
+  lookup_qs_sub_x <- arrange(
+    lookup_qs_sub_x,
     USUBJID,
     VISITNUM
   )
@@ -432,8 +432,8 @@ get_qs_data <- function(adsl,
   # if no treatment end date, create an arbituary one
   trt_end_date <- max(adsl_trt$TRTEDTM, na.rm = TRUE)
 
-  lookup_QS_sub_x <- left_join(
-    lookup_QS_sub_x,
+  lookup_qs_sub_x <- left_join(
+    lookup_qs_sub_x,
     adsl_trt,
     by = "USUBJID"
   ) %>%
@@ -452,14 +452,14 @@ get_qs_data <- function(adsl,
     select(-c("TRTSDTM", "TRTEDTM"))
 
   # filter out subjects with missing dates
-  lookup_QS_sub_x1 <- filter(
-    lookup_QS_sub_x,
+  lookup_qs_sub_x1 <- filter(
+    lookup_qs_sub_x,
     !is.na(QSDTC)
   )
 
   # subjects with missing dates
-  lookup_QS_sub_x2 <- filter(
-    lookup_QS_sub_x,
+  lookup_qs_sub_x2 <- filter(
+    lookup_qs_sub_x,
     is.na(QSDTC)
   ) %>%
     select(
@@ -472,7 +472,7 @@ get_qs_data <- function(adsl,
 
   # generate QSALL for subjects with missing dates
   qsall_data2 <- mutate(
-    lookup_QS_sub_x2,
+    lookup_qs_sub_x2,
     QSTESTCD = "QSALL",
     QSTEST = "Questionnaires",
     QSSTAT = "NOT DONE",
@@ -480,13 +480,13 @@ get_qs_data <- function(adsl,
   )
 
   # add qsall data to original item data
-  lookup_QS_sub_all <- bind_rows(
-    lookup_QS_sub_x1,
+  lookup_qs_sub_all <- bind_rows(
+    lookup_qs_sub_x1,
     qsall_data1,
     qsall_data2
   )
 
-  QS_all <- lookup_QS_sub_all %>%
+  qs_all <- lookup_qs_sub_all %>%
     arrange(
       STUDYID,
       USUBJID,
@@ -496,37 +496,37 @@ get_qs_data <- function(adsl,
     dplyr::ungroup()
 
   # get first and second subject ids
-  first_second_subj <- select(QS_all, USUBJID) %>%
+  first_second_subj <- select(qs_all, USUBJID) %>%
     distinct() %>%
     slice(1:2)
 
-  QS1 <- filter(
-    QS_all,
+  qs1 <- filter(
+    qs_all,
     USUBJID %in% first_second_subj$USUBJID
   )
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    QS1 <- mutate_na(ds = QS1, na_vars = na_vars, na_percentage = na_percentage)
+    qs1 <- mutate_na(ds = qs1, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # QSSTAT = NOT DONE
-  QS1 <- mutate(
-    QS1,
+  qs1 <- mutate(
+    qs1,
     QSSTAT = case_when(
       is.na(QSORRES) & is.na(QSSTRESC) ~ "NOT DONE"
     )
   )
 
   # remove first and second subjects from main data
-  QS2 <- anti_join(
-    QS_all,
-    QS1,
+  qs2 <- anti_join(
+    qs_all,
+    qs1,
     by = c("USUBJID")
   )
 
-  final_QS <- rbind(
-    QS1,
-    QS2
+  final_qs <- rbind(
+    qs1,
+    qs2
   ) %>%
     group_by(USUBJID) %>%
     dplyr::mutate(QSSEQ = row_number()) %>%
@@ -538,8 +538,8 @@ get_qs_data <- function(adsl,
     ungroup()
 
   # ordered variables as per gdsr
-  final_QS <- select(
-    final_QS,
+  final_qs <- select(
+    final_qs,
     STUDYID,
     USUBJID,
     QSSEQ,
@@ -558,7 +558,7 @@ get_qs_data <- function(adsl,
     QSDTC,
     QSEVLINT
   )
-  return(final_QS)
+  return(final_qs)
 }
 
 #' @describeIn h_adqlqc Function for generating random dates between 2 dates
@@ -573,7 +573,7 @@ get_qs_data <- function(adsl,
 #' @examples
 #' df <- dplyr::left_join(
 #'   adsl,
-#'   QS,
+#'   qs,
 #'   by = c("STUDYID", "USUBJID"),
 #'   multiple = "all"
 #' ) |>
@@ -615,8 +615,8 @@ get_random_dates_between <- function(from, to, visit_id) {
 #' @keywords internal
 #'
 #' @examples
-#' ADQLQC1 <- random.cdisc.data:::prep_adqlqc(df = QS)
-#' ADQLQC1
+#' adqlqc1 <- random.cdisc.data:::prep_adqlqc(df = qs)
+#' adqlqc1
 prep_adqlqc <- function(df) {
   # create PARAMCD from QSTESTCD
   adqlqc <- dplyr::mutate(
@@ -934,13 +934,13 @@ calc_scales <- function(adqlqc1) {
       PARCAT1N = ifelse(PARAMCD == "EX028", expect$PARCAT1N, PARCAT1N)
     )
 
-  ADQLQCtmp <- bind_rows(adqlqc1, df_saved1) %>%
+  adqlqc_tmp <- bind_rows(adqlqc1, df_saved1) %>%
     arrange(
       USUBJID,
       AVISITN,
       QSTESTCD
     )
-  return(ADQLQCtmp)
+  return(adqlqc_tmp)
 }
 
 #' @describeIn h_adqlqc Calculate Change from Baseline Category 1
@@ -951,8 +951,8 @@ calc_scales <- function(adqlqc1) {
 #' @keywords internal
 #'
 #' @examples
-#' ADQLQC <- random.cdisc.data:::derv_chgcat1(dataset = ADQLQC |> dplyr::select(-CHGCAT1))
-#' ADQLQC
+#' adqlqc <- random.cdisc.data:::derv_chgcat1(dataset = adqlqc |> dplyr::select(-CHGCAT1))
+#' adqlqc
 derv_chgcat1 <- function(dataset) {
   # derivation of CHGCAT1
   check_vars <- c("PARCAT2", "CHG")
@@ -1115,7 +1115,7 @@ derv_chgcat1 <- function(dataset) {
 #' @keywords internal
 #'
 #' @examples
-#' compliance_data <- random.cdisc.data:::comp_derv(ADQLQC, 80, 2)
+#' compliance_data <- random.cdisc.data:::comp_derv(adqlqc, 80, 2)
 #' compliance_data
 comp_derv <- function(dataset, percent, number) {
   # original items data

--- a/R/radqlqc.R
+++ b/R/radqlqc.R
@@ -805,24 +805,24 @@ calc_scales <- function(adqlqc1) {
     "1"
   )
   df$equation <- list(
-    "newValue = (1 - ((tempVal/varLength)-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0",
-    "newValue = (1 - ((tempVal/varLength)-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0",
-    "newValue = (1 - ((tempVal/varLength)-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/6)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0",
-    "newValue = (1 - ((tempVal/varLength)-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0",
-    "newValue = (1 - ((tempVal/varLength)-1)/3)*100.0",
-    "newValue = ((tempVal/varLength-1)/3)*100.0"
+    "new_value = (1 - ((temp_val/var_length)-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0",
+    "new_value = (1 - ((temp_val/var_length)-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0",
+    "new_value = (1 - ((temp_val/var_length)-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/6)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0",
+    "new_value = (1 - ((temp_val/var_length)-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0",
+    "new_value = (1 - ((temp_val/var_length)-1)/3)*100.0",
+    "new_value = ((temp_val/var_length-1)/3)*100.0"
   )
 
-  expectData <- data.frame(
+  expect_data <- data.frame(
     PARAM = expect$PARAM,
     PARAMCD = expect$PARAMCD,
     PARCAT2 = expect$PARCAT2,
@@ -836,52 +836,52 @@ calc_scales <- function(adqlqc1) {
 
   df_saved <- data.frame()
 
-  uniqueID <- unique(adqlqc1$USUBJID)
+  unique_id <- unique(adqlqc1$USUBJID)
 
-  for (id in uniqueID) {
-    idData <- adqlqc1[adqlqc1$USUBJID == id, ]
-    uniqueAvisit <- unique(idData$AVISIT)
-    for (visit in uniqueAvisit) {
+  for (id in unique_id) {
+    id_data <- adqlqc1[adqlqc1$USUBJID == id, ]
+    unique_avisit <- unique(id_data$AVISIT)
+    for (visit in unique_avisit) {
       if (is.na(visit)) {
         next
       }
-      idData_at_visit <- idData[idData$AVISIT == visit, ]
+      id_data_at_visit <- id_data[id_data$AVISIT == visit, ]
 
-      if (any(idData_at_visit$PARAMCD != "QSALL")) {
+      if (any(id_data_at_visit$PARAMCD != "QSALL")) {
         for (idx in seq_along(df$index)) {
-          previousNames <- df$previous[idx]
-          currentName <- df$newName[idx]
-          currentNamelabel <- df$newNamelabel[idx]
-          currentNameCategory <- df$newNameCategory[idx]
+          previous_names <- df$previous[idx]
+          current_name <- df$newName[idx]
+          current_name_label <- df$newNamelabel[idx]
+          current_name_category <- df$newNameCategory[idx]
           eqn <- df$equation[idx]
-          tempVal <- 0
-          varLength <- 0
-          for (paramName in previousNames[[1]]) {
-            if (paramName %in% idData_at_visit$PARAMCD) { ####
-              currentVal <- as.numeric(as.character(idData_at_visit$AVAL[idData_at_visit$PARAMCD == paramName]))
-              if (!is.na(currentVal)) {
-                tempVal <- tempVal + currentVal ###
-                varLength <- varLength + 1
+          temp_val <- 0
+          var_length <- 0
+          for (param_name in previous_names[[1]]) {
+            if (param_name %in% id_data_at_visit$PARAMCD) { ####
+              current_val <- as.numeric(as.character(id_data_at_visit$AVAL[id_data_at_visit$PARAMCD == param_name]))
+              if (!is.na(current_val)) {
+                temp_val <- temp_val + current_val ###
+                var_length <- var_length + 1
               }
             } # if
-          } # paramName
+          } # param_name
           # eval
-          if (varLength >= as.numeric(df$num_param[idx])) {
+          if (var_length >= as.numeric(df$num_param[idx])) {
             eval(parse(text = eqn)) #####
           } else {
-            newValue <- NA
+            new_value <- NA
           }
 
           new_data_row <- data.frame(
             study = str_extract(id, "[A-Z]+[0-9]+"),
             id,
             visit,
-            idData_at_visit$AVISITN[1],
-            idData_at_visit$QSDTC[1],
-            currentNameCategory,
-            currentNamelabel,
-            currentName,
-            newValue,
+            id_data_at_visit$AVISITN[1],
+            id_data_at_visit$QSDTC[1],
+            current_name_category,
+            current_name_label,
+            current_name,
+            new_value,
             NA,
             stringsAsFactors = FALSE
           )
@@ -894,20 +894,20 @@ calc_scales <- function(adqlqc1) {
         } # idx
       }
       # add expect data
-      expectValue <- sample(expectData$AVAL, 1, prob = c(0.10, 0.90))
-      expectValueC <- expectData$AVALC[expectData$AVAL == expectValue]
+      expect_value <- sample(expect_data$AVAL, 1, prob = c(0.10, 0.90))
+      expect_valuec <- expect_data$AVALC[expect_data$AVAL == expect_value]
 
       new_data_row <- data.frame(
         study = str_extract(id, "[A-Z]+[0-9]+"),
         id,
         visit,
-        idData_at_visit$AVISITN[1],
+        id_data_at_visit$AVISITN[1],
         datetime = NA,
-        expectData$PARCAT2[1],
-        expectData$PARAM[1],
-        expectData$PARAMCD[1],
-        expectValue,
-        expectValueC,
+        expect_data$PARCAT2[1],
+        expect_data$PARAM[1],
+        expect_data$PARAMCD[1],
+        expect_value,
+        expect_valuec,
         stringsAsFactors = FALSE
       )
       colnames(new_data_row) <- c(

--- a/R/radqs.R
+++ b/R/radqs.R
@@ -187,7 +187,7 @@ radqs <- function(adsl,
   }
 
   # apply metadata
-  adqs <- apply_metadata(adqs, "metadata/adqs.yml")
+  adqs <- apply_metadata(adqs, "metadata/ADQS.yml")
 
   return(adqs)
 }

--- a/R/radqs.R
+++ b/R/radqs.R
@@ -20,14 +20,14 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADQS <- radqs(ADSL, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+#' ADQS <- radqs(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
 #' ADQS
 #'
-#' ADQS <- radqs(ADSL, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
+#' ADQS <- radqs(adsl, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
 #' ADQS
-radqs <- function(ADSL,
+radqs <- function(adsl,
                   param = c(
                     "BFI All Questions",
                     "Fatigue Interference",
@@ -51,7 +51,7 @@ radqs <- function(ADSL,
     return(get_cached_data("cadqs"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(param, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramcd, min.len = 1, any.missing = FALSE)
   checkmate::assert_string(visit_format)
@@ -67,11 +67,11 @@ radqs <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   ADQS <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PARAM = param_init_list$relvar1,
     AVISIT = visit_schedule(visit_format = visit_format, n_assessments = n_assessments, n_days = n_days),
     stringsAsFactors = FALSE
@@ -104,7 +104,7 @@ radqs <- function(ADSL,
     lapply(
       split(ADQS, ADQS$USUBJID),
       function(x) {
-        x$STUDYID <- ADSL$STUDYID[which(ADSL$USUBJID == x$USUBJID[1])]
+        x$STUDYID <- adsl$STUDYID[which(adsl$USUBJID == x$USUBJID[1])]
         x$ABLFL2 <- ifelse(x$AVISIT == "SCREENING", "Y", "")
         x$ABLFL <- ifelse(
           toupper(visit_format) == "WEEK" & x$AVISIT == "BASELINE",
@@ -130,8 +130,8 @@ radqs <- function(ADSL,
     dplyr::mutate(CHG = AVAL - BASE) %>%
     dplyr::mutate(PCHG = 100 * (CHG / BASE)) %>%
     var_relabel(
-      STUDYID = attr(ADSL$STUDYID, "label"),
-      USUBJID = attr(ADSL$USUBJID, "label")
+      STUDYID = attr(adsl$STUDYID, "label"),
+      USUBJID = attr(adsl$USUBJID, "label")
     )
 
   ADQS <- var_relabel(
@@ -143,7 +143,7 @@ radqs <- function(ADSL,
   # merge ADSL to be able to add QS date and study day variables
   ADQS <- dplyr::inner_join(
     ADQS,
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::rowwise() %>%

--- a/R/radrs.R
+++ b/R/radrs.R
@@ -22,11 +22,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADRS <- radrs(ADSL, seed = 2)
+#' ADRS <- radrs(adsl, seed = 2)
 #' ADRS
-radrs <- function(ADSL,
+radrs <- function(adsl,
                   avalc = NULL,
                   lookup = NULL,
                   seed = NULL,
@@ -38,7 +38,7 @@ radrs <- function(ADSL,
     return(get_cached_data("cadrs"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_vector(avalc, null.ok = TRUE)
   checkmate::assert_number(seed, null.ok = TRUE)
   checkmate::assert_number(na_percentage, lower = 0, upper = 1)
@@ -70,9 +70,9 @@ radrs <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
-  ADRS <- split(ADSL, ADSL$USUBJID) %>%
+  ADRS <- split(adsl, adsl$USUBJID) %>%
     lapply(function(pinfo) {
       probs <- dplyr::filter(lookup_ARS, ARM == as.character(pinfo$ACTARM))
 
@@ -162,7 +162,7 @@ radrs <- function(ADSL,
 
   ADRS <- dplyr::inner_join(
     dplyr::select(ADRS, -"SITEID"),
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   )
 

--- a/R/radrs.R
+++ b/R/radrs.R
@@ -185,7 +185,7 @@ radrs <- function(adsl,
   }
 
   # apply metadata
-  adrs <- apply_metadata(adrs, "metadata/adrs.yml")
+  adrs <- apply_metadata(adrs, "metadata/ADRS.yml")
 
   return(adrs)
 }

--- a/R/radrs.R
+++ b/R/radrs.R
@@ -98,17 +98,17 @@ radrs <- function(adsl,
       avisit <- c("SCREENING", "BASELINE", "CYCLE 2 DAY 1", "CYCLE 4 DAY 1", "END OF INDUCTION", "FOLLOW UP")
 
       # meaningful date information
-      TRTSTDT <- lubridate::date(pinfo$TRTSDTM)
-      TRTENDT <- lubridate::date(dplyr::if_else(
+      trtstdt <- lubridate::date(pinfo$TRTSDTM)
+      trtendt <- lubridate::date(dplyr::if_else(
         !is.na(pinfo$TRTEDTM), pinfo$TRTEDTM,
-        lubridate::floor_date(TRTSTDT + study_duration_secs, unit = "day")
+        lubridate::floor_date(trtstdt + study_duration_secs, unit = "day")
       ))
-      scr_date <- TRTSTDT - lubridate::days(100)
-      bs_date <- TRTSTDT
-      flu_date <- sample(seq(lubridate::as_datetime(TRTSTDT), lubridate::as_datetime(TRTENDT), by = "day"), size = 1)
-      eoi_date <- sample(seq(lubridate::as_datetime(TRTSTDT), lubridate::as_datetime(TRTENDT), by = "day"), size = 1)
-      c2d1_date <- sample(seq(lubridate::as_datetime(TRTSTDT), lubridate::as_datetime(TRTENDT), by = "day"), size = 1)
-      c4d1_date <- min(lubridate::date(c2d1_date + lubridate::days(60)), TRTENDT)
+      scr_date <- trtstdt - lubridate::days(100)
+      bs_date <- trtstdt
+      flu_date <- sample(seq(lubridate::as_datetime(trtstdt), lubridate::as_datetime(trtendt), by = "day"), size = 1)
+      eoi_date <- sample(seq(lubridate::as_datetime(trtstdt), lubridate::as_datetime(trtendt), by = "day"), size = 1)
+      c2d1_date <- sample(seq(lubridate::as_datetime(trtstdt), lubridate::as_datetime(trtendt), by = "day"), size = 1)
+      c4d1_date <- min(lubridate::date(c2d1_date + lubridate::days(60)), trtendt)
 
       tibble::tibble(
         STUDYID = pinfo$STUDYID,

--- a/R/radrs.R
+++ b/R/radrs.R
@@ -24,8 +24,8 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADRS <- radrs(adsl, seed = 2)
-#' ADRS
+#' adrs <- radrs(adsl, seed = 2)
+#' adrs
 radrs <- function(adsl,
                   avalc = NULL,
                   lookup = NULL,
@@ -51,7 +51,7 @@ radrs <- function(adsl,
   }
 
   checkmate::assert_data_frame(lookup, null.ok = TRUE)
-  lookup_ARS <- if (!is.null(lookup)) {
+  lookup_ars <- if (!is.null(lookup)) {
     lookup
   } else {
     expand.grid(
@@ -72,9 +72,9 @@ radrs <- function(adsl,
   }
   study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
-  ADRS <- split(adsl, adsl$USUBJID) %>%
+  adrs <- split(adsl, adsl$USUBJID) %>%
     lapply(function(pinfo) {
-      probs <- dplyr::filter(lookup_ARS, ARM == as.character(pinfo$ACTARM))
+      probs <- dplyr::filter(lookup_ars, ARM == as.character(pinfo$ACTARM))
 
       # screening
       rsp_screen <- sample(probs$AVALC, 1, prob = probs$p_scr) %>% as.character()
@@ -151,8 +151,8 @@ radrs <- function(adsl,
       USUBJID = "Unique Subject Identifier"
     )
 
-  ADRS <- var_relabel(
-    ADRS,
+  adrs <- var_relabel(
+    adrs,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
@@ -160,13 +160,13 @@ radrs <- function(adsl,
   # merge ADSL to be able to add RS date and study day variables
 
 
-  ADRS <- dplyr::inner_join(
-    dplyr::select(ADRS, -"SITEID"),
+  adrs <- dplyr::inner_join(
+    dplyr::select(adrs, -"SITEID"),
     adsl,
     by = c("STUDYID", "USUBJID")
   )
 
-  ADRS <- ADRS %>%
+  adrs <- adrs %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(RSSEQ = seq_len(dplyr::n())) %>%
     dplyr::mutate(ASEQ = RSSEQ) %>%
@@ -181,11 +181,11 @@ radrs <- function(adsl,
     )
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADRS <- mutate_na(ds = ADRS, na_vars = na_vars, na_percentage = na_percentage)
+    adrs <- mutate_na(ds = adrs, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # apply metadata
-  ADRS <- apply_metadata(ADRS, "metadata/ADRS.yml")
+  adrs <- apply_metadata(adrs, "metadata/adrs.yml")
 
-  return(ADRS)
+  return(adrs)
 }

--- a/R/radsaftte.R
+++ b/R/radsaftte.R
@@ -17,8 +17,8 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADSAFTTE <- radsaftte(adsl, seed = 2)
-#' ADSAFTTE
+#' adsaftte <- radsaftte(adsl, seed = 2)
+#' adsaftte
 radsaftte <- function(adsl,
                       ...) {
   radaette(adsl = adsl, ...)

--- a/R/radsaftte.R
+++ b/R/radsaftte.R
@@ -15,11 +15,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADSAFTTE <- radsaftte(ADSL, seed = 2)
+#' ADSAFTTE <- radsaftte(adsl, seed = 2)
 #' ADSAFTTE
-radsaftte <- function(ADSL,
+radsaftte <- function(adsl,
                       ...) {
-  radaette(ADSL = ADSL, ...)
+  radaette(adsl = adsl, ...)
 }

--- a/R/radsl.R
+++ b/R/radsl.R
@@ -43,7 +43,7 @@
 #'
 #' adsl <- radsl(N = 10, seed = 1, na_percentage = .1)
 #' adsl
-radsl <- function(N = 400,
+radsl <- function(N = 400, # nolint
                   study_duration = 2,
                   seed = NULL,
                   with_trt02 = TRUE,

--- a/R/radsl.R
+++ b/R/radsl.R
@@ -263,7 +263,7 @@ radsl <- function(N = 400, # nolint
   }
 
   # apply metadata
-  adsl <- apply_metadata(adsl, "metadata/adsl.yml", FALSE)
+  adsl <- apply_metadata(adsl, "metadata/ADSL.yml", FALSE)
 
   attr(adsl, "study_duration_secs") <- as.numeric(study_duration_secs) # nolint
   return(adsl)

--- a/R/radsl.R
+++ b/R/radsl.R
@@ -265,6 +265,6 @@ radsl <- function(N = 400, # nolint
   # apply metadata
   adsl <- apply_metadata(adsl, "metadata/ADSL.yml", FALSE)
 
-  attr(adsl, "study_duration_secs") <- as.numeric(study_duration_secs) # nolint
+  attr(adsl, "study_duration_secs") <- as.numeric(study_duration_secs)
   return(adsl)
 }

--- a/R/radsl.R
+++ b/R/radsl.R
@@ -116,7 +116,7 @@ radsl <- function(N = 400,
     dplyr::mutate(SAFFL = factor("Y")) %>%
     dplyr::arrange(TRTSDTM)
 
-  ADDS <- adsl[sample(nrow(adsl), discons), ] %>%
+  adds <- adsl[sample(nrow(adsl), discons), ] %>%
     dplyr::mutate(TRTEDTM_discon = sample(
       seq(from = max(TRTSDTM), to = sys_dtm + study_duration_secs, by = 1),
       size = discons,
@@ -125,7 +125,7 @@ radsl <- function(N = 400,
     dplyr::select(SUBJID, TRTSDTM, TRTEDTM_discon) %>%
     dplyr::arrange(TRTSDTM)
 
-  adsl <- dplyr::left_join(adsl, ADDS, by = c("SUBJID", "TRTSDTM")) %>%
+  adsl <- dplyr::left_join(adsl, adds, by = c("SUBJID", "TRTSDTM")) %>%
     dplyr::mutate(TRTEDTM = dplyr::case_when(
       !is.na(TRTEDTM_discon) ~ TRTEDTM_discon,
       TRTSDTM >= quantile(TRTSDTM)[2] & TRTSDTM <= quantile(TRTSDTM)[3] ~ lubridate::as_datetime(NA),
@@ -263,7 +263,7 @@ radsl <- function(N = 400,
   }
 
   # apply metadata
-  adsl <- apply_metadata(adsl, "metadata/ADSL.yml", FALSE)
+  adsl <- apply_metadata(adsl, "metadata/adsl.yml", FALSE)
 
   attr(adsl, "study_duration_secs") <- as.numeric(study_duration_secs) # nolint
   return(adsl)

--- a/R/radsub.R
+++ b/R/radsub.R
@@ -244,7 +244,7 @@ radsub <- function(adsl,
   }
 
   # Apply metadata.
-  adsub <- apply_metadata(adsub, "metadata/adsub.yml")
+  adsub <- apply_metadata(adsub, "metadata/ADSUB.yml")
 
   return(adsub)
 }

--- a/R/radsub.R
+++ b/R/radsub.R
@@ -22,9 +22,9 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 5, seed = 1)
+#' adsl <- radsl(N = 5, seed = 1)
 #'
-#' df_with_measurements <- random.cdisc.data:::h_anthropometrics_by_sex(df = ADSL)
+#' df_with_measurements <- random.cdisc.data:::h_anthropometrics_by_sex(df = adsl)
 #' df_with_measurements
 h_anthropometrics_by_sex <- function(df,
                                      seed = 1,
@@ -98,11 +98,11 @@ h_anthropometrics_by_sex <- function(df,
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADSUB <- radsub(ADSL, seed = 2)
+#' ADSUB <- radsub(adsl, seed = 2)
 #' ADSUB
-radsub <- function(ADSL,
+radsub <- function(adsl,
                    param = c(
                      "Baseline Weight",
                      "Baseline Height",
@@ -120,7 +120,7 @@ radsub <- function(ADSL,
     return(get_cached_data("cadsub"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(param, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramcd, min.len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
@@ -135,8 +135,8 @@ radsub <- function(ADSL,
   }
 
   ADSUB <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
     AVISIT = "BASELINE",
     stringsAsFactors = FALSE
@@ -161,7 +161,7 @@ radsub <- function(ADSL,
   # Sample ADTM to be a few days before TRTSDTM.
   ADSUB <- dplyr::inner_join(
     ADSUB,
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::group_by(USUBJID) %>%

--- a/R/radsub.R
+++ b/R/radsub.R
@@ -100,8 +100,8 @@ h_anthropometrics_by_sex <- function(df,
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADSUB <- radsub(adsl, seed = 2)
-#' ADSUB
+#' adsub <- radsub(adsl, seed = 2)
+#' adsub
 radsub <- function(adsl,
                    param = c(
                      "Baseline Weight",
@@ -134,7 +134,7 @@ radsub <- function(adsl,
     set.seed(seed)
   }
 
-  ADSUB <- expand.grid(
+  adsub <- expand.grid(
     STUDYID = unique(adsl$STUDYID),
     USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
@@ -143,24 +143,24 @@ radsub <- function(adsl,
   )
 
   # Assign related variable values: PARAM and PARAMCD are related.
-  ADSUB <- ADSUB %>% rel_var(
+  adsub <- adsub %>% rel_var(
     var_name = "PARAMCD",
     related_var = "PARAM",
     var_values = param_init_list$relvar2
   )
 
-  ADSUB <- ADSUB[order(ADSUB$STUDYID, ADSUB$USUBJID, ADSUB$PARAMCD), ]
+  adsub <- adsub[order(adsub$STUDYID, adsub$USUBJID, adsub$PARAMCD), ]
 
-  ADSUB <- var_relabel(
-    ADSUB,
+  adsub <- var_relabel(
+    adsub,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
 
   # Merge ADSL to be able to add EG date and study day variables.
   # Sample ADTM to be a few days before TRTSDTM.
-  ADSUB <- dplyr::inner_join(
-    ADSUB,
+  adsub <- dplyr::inner_join(
+    adsub,
     adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
@@ -174,13 +174,13 @@ radsub <- function(adsl,
 
   # Generate a dataset with height, weight and BMI measurements for each subject.
   if (!is.null(seed)) {
-    df_with_measurements <- h_anthropometrics_by_sex(ADSUB, seed = seed)
+    df_with_measurements <- h_anthropometrics_by_sex(adsub, seed = seed)
   } else {
-    df_with_measurements <- h_anthropometrics_by_sex(ADSUB)
+    df_with_measurements <- h_anthropometrics_by_sex(adsub)
   }
 
-  # Add this to ADSUB and create other measurements.
-  ADSUB <- ADSUB %>%
+  # Add this to adsub and create other measurements.
+  adsub <- adsub %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(
       AVAL = dplyr::case_when(
@@ -201,7 +201,7 @@ radsub <- function(adsl,
       TRUE ~ round(AVAL)
     ))
 
-  ADSUB <- ADSUB %>%
+  adsub <- adsub %>%
     dplyr::mutate(
       AVALC = dplyr::case_when(
         PARAMCD == "BBMRKR1" ~ dplyr::case_when(
@@ -240,11 +240,11 @@ radsub <- function(adsl,
     )
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADSUB <- mutate_na(ds = ADSUB, na_vars = na_vars, na_percentage = na_percentage)
+    adsub <- mutate_na(ds = adsub, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # Apply metadata.
-  ADSUB <- apply_metadata(ADSUB, "metadata/ADSUB.yml")
+  adsub <- apply_metadata(adsub, "metadata/adsub.yml")
 
-  return(ADSUB)
+  return(adsub)
 }

--- a/R/radtr.R
+++ b/R/radtr.R
@@ -23,8 +23,8 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADTR <- radtr(adsl, seed = 2)
-#' ADTR
+#' adtr <- radtr(adsl, seed = 2)
+#' adtr
 radtr <- function(adsl,
                   param = c("Sum of Longest Diameter by Investigator"),
                   paramcd = c("SLDINV"),
@@ -58,7 +58,7 @@ radtr <- function(adsl,
       "ADY"
     )
 
-  ADTR <- Map(function(parcd, par) {
+  adtr <- Map(function(parcd, par) {
     df <- adrs
     df$AVAL <- stats::rnorm(nrow(df), mean = 150, sd = 30)
     df$PARAMCD <- parcd
@@ -67,13 +67,13 @@ radtr <- function(adsl,
   }, paramcd, param) %>%
     Reduce(rbind, .)
 
-  ADTR_base <- ADTR %>%
+  adtr_base <- adtr %>%
     dplyr::filter(AVISITN == 0) %>%
     dplyr::group_by(USUBJID, PARAMCD) %>%
     dplyr::mutate(BASE = AVAL) %>%
     dplyr::select("STUDYID", "USUBJID", "BASE", "PARAMCD")
 
-  ADTR_postbase <- ADTR %>%
+  adtr_postbase <- adtr %>%
     dplyr::filter(AVISITN > 0) %>%
     dplyr::filter(!is.na(AVAL)) %>%
     dplyr::group_by(USUBJID, PARAMCD) %>%
@@ -83,7 +83,7 @@ radtr <- function(adsl,
     dplyr::mutate(DTYPE = "MINIMUM") %>%
     dplyr::ungroup()
 
-  ADTR_lastobs <- ADTR %>%
+  adtr_lastobs <- adtr %>%
     dplyr::filter(AVISITN > 0) %>%
     dplyr::filter(!is.na(AVAL)) %>%
     dplyr::group_by(USUBJID, PARAMCD) %>%
@@ -98,9 +98,9 @@ radtr <- function(adsl,
       "LAST_VISIT"
     )
 
-  ADTR <- rbind(ADTR %>% dplyr::mutate(DTYPE = ""), ADTR_postbase)
+  adtr <- rbind(adtr %>% dplyr::mutate(DTYPE = ""), adtr_postbase)
 
-  ADTR <- merge(ADTR, ADTR_base, by = c("STUDYID", "USUBJID", "PARAMCD")) %>%
+  adtr <- merge(adtr, adtr_base, by = c("STUDYID", "USUBJID", "PARAMCD")) %>%
     dplyr::mutate(
       ABLFL = dplyr::case_when(AVISIT == "BASELINE" ~ "Y", TRUE ~ ""),
       AVAL = dplyr::case_when(AVISIT == "BASELINE" ~ NA_real_, TRUE ~ AVAL),
@@ -111,7 +111,7 @@ radtr <- function(adsl,
     )
 
   # ensure PCHG does not exceed 200%, nor go below -100% (double in size, or complete remission of tumor).
-  ADTR <- ADTR %>%
+  adtr <- adtr %>%
     dplyr::mutate(
       PCHG_DUM = PCHG,
       PCHG = dplyr::case_when(
@@ -132,7 +132,7 @@ radtr <- function(adsl,
     ) %>%
     dplyr::select(-"PCHG_DUM")
 
-  ADTR <- merge(adsl, ADTR, by = c("STUDYID", "USUBJID")) %>%
+  adtr <- merge(adsl, adtr, by = c("STUDYID", "USUBJID")) %>%
     dplyr::group_by(USUBJID, PARAMCD) %>%
     dplyr::mutate(
       ONTRTFL = factor(dplyr::case_when(
@@ -149,7 +149,7 @@ radtr <- function(adsl,
         TRUE ~ ""
       )
     )
-  ADTR <- merge(ADTR, ADTR_lastobs, by = c("STUDYID", "USUBJID", "PARAMCD")) %>%
+  adtr <- merge(adtr, adtr_lastobs, by = c("STUDYID", "USUBJID", "PARAMCD")) %>%
     dplyr::mutate(
       ANL02FL = dplyr::case_when(
         as.character(AVISIT) == as.character(LAST_VISIT) ~ "Y",
@@ -159,7 +159,7 @@ radtr <- function(adsl,
     ) %>%
     dplyr::select(-"LAST_VISIT")
   # Adding variables that are in ADTR osprey but not RCD.
-  ADTR <- ADTR %>%
+  adtr <- adtr %>%
     dplyr::mutate(
       DCSREAS_GRP = ifelse(DCSREAS == "ADVERSE EVENT", "Safety", "Non-Safety"),
       TRTDURD = ifelse(
@@ -171,6 +171,6 @@ radtr <- function(adsl,
     )
 
   # apply metadata
-  ADTR <- apply_metadata(ADTR, "metadata/ADTR.yml")
-  return(ADTR)
+  adtr <- apply_metadata(adtr, "metadata/adtr.yml")
+  return(adtr)
 }

--- a/R/radtr.R
+++ b/R/radtr.R
@@ -21,11 +21,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADTR <- radtr(ADSL, seed = 2)
+#' ADTR <- radtr(adsl, seed = 2)
 #' ADTR
-radtr <- function(ADSL,
+radtr <- function(adsl,
                   param = c("Sum of Longest Diameter by Investigator"),
                   paramcd = c("SLDINV"),
                   seed = NULL,
@@ -35,7 +35,7 @@ radtr <- function(ADSL,
   if (cached) {
     return(get_cached_data("cadtr"))
   }
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(param, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramcd, min.len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
@@ -47,7 +47,7 @@ radtr <- function(ADSL,
   }
 
   # Make times consistent with ADRS at ADY and ADTM.
-  adrs <- radrs(ADSL, seed = seed, ...) %>%
+  adrs <- radrs(adsl, seed = seed, ...) %>%
     dplyr::filter(PARAMCD == "OVRINV") %>%
     dplyr::select(
       "STUDYID",
@@ -132,7 +132,7 @@ radtr <- function(ADSL,
     ) %>%
     dplyr::select(-"PCHG_DUM")
 
-  ADTR <- merge(ADSL, ADTR, by = c("STUDYID", "USUBJID")) %>%
+  ADTR <- merge(adsl, ADTR, by = c("STUDYID", "USUBJID")) %>%
     dplyr::group_by(USUBJID, PARAMCD) %>%
     dplyr::mutate(
       ONTRTFL = factor(dplyr::case_when(

--- a/R/radtr.R
+++ b/R/radtr.R
@@ -171,6 +171,6 @@ radtr <- function(adsl,
     )
 
   # apply metadata
-  adtr <- apply_metadata(adtr, "metadata/adtr.yml")
+  adtr <- apply_metadata(adtr, "metadata/ADTR.yml")
   return(adtr)
 }

--- a/R/radtte.R
+++ b/R/radtte.R
@@ -19,11 +19,11 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADTTE <- radtte(ADSL, seed = 2)
+#' ADTTE <- radtte(adsl, seed = 2)
 #' ADTTE
-radtte <- function(ADSL,
+radtte <- function(adsl,
                    event.descr = NULL,
                    censor.descr = NULL,
                    lookup = NULL,
@@ -36,7 +36,7 @@ radtte <- function(ADSL,
     return(get_cached_data("cadtte"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(censor.descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(event.descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
@@ -46,7 +46,7 @@ radtte <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   checkmate::assert_data_frame(lookup, null.ok = TRUE)
   lookup_TTE <- if (!is.null(lookup)) {
@@ -92,7 +92,7 @@ radtte <- function(ADSL,
     )
   }
 
-  ADTTE <- split(ADSL, ADSL$USUBJID) %>%
+  ADTTE <- split(adsl, adsl$USUBJID) %>%
     lapply(FUN = function(pinfo) {
       lookup_TTE %>%
         dplyr::filter(ARM == as.character(pinfo$ACTARMCD)) %>%
@@ -131,7 +131,7 @@ radtte <- function(ADSL,
   # merge ADSL to be able to add TTE date and study day variables
   ADTTE <- dplyr::inner_join(
     dplyr::select(ADTTE, -"SITEID", -"ARM"),
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::rowwise() %>%

--- a/R/radtte.R
+++ b/R/radtte.R
@@ -196,7 +196,7 @@ radtte <- function(adsl,
   }
 
   # apply metadata
-  adtte <- apply_metadata(adtte, "metadata/adtte.yml")
+  adtte <- apply_metadata(adtte, "metadata/ADTTE.yml")
 
   return(adtte)
 }

--- a/R/radtte.R
+++ b/R/radtte.R
@@ -24,8 +24,8 @@
 #' adtte <- radtte(adsl, seed = 2)
 #' adtte
 radtte <- function(adsl,
-                   event.descr = NULL,
-                   censor.descr = NULL,
+                   event_descr = NULL,
+                   censor_descr = NULL,
                    lookup = NULL,
                    seed = NULL,
                    na_percentage = 0,
@@ -37,8 +37,8 @@ radtte <- function(adsl,
   }
 
   checkmate::assert_data_frame(adsl)
-  checkmate::assert_character(censor.descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
-  checkmate::assert_character(event.descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
+  checkmate::assert_character(censor_descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
+  checkmate::assert_character(event_descr, null.ok = TRUE, min.len = 1, any.missing = FALSE)
   checkmate::assert_number(seed, null.ok = TRUE)
   checkmate::assert_number(na_percentage, lower = 0, upper = 1)
   checkmate::assert_true(na_percentage < 1)
@@ -69,8 +69,8 @@ radtte <- function(adsl,
     )
   }
 
-  evntdescr_sel <- if (!is.null(event.descr)) {
-    event.descr
+  evntdescr_sel <- if (!is.null(event_descr)) {
+    event_descr
   } else {
     c(
       "Death",
@@ -81,8 +81,8 @@ radtte <- function(adsl,
     )
   }
 
-  cnsdtdscr_sel <- if (!is.null(censor.descr)) {
-    censor.descr
+  cnsdtdscr_sel <- if (!is.null(censor_descr)) {
+    censor_descr
   } else {
     c(
       "Preferred Term",

--- a/R/radvs.R
+++ b/R/radvs.R
@@ -20,14 +20,14 @@
 #'
 #' @examples
 #' library(random.cdisc.data)
-#' ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+#' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADVS <- radvs(ADSL, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+#' ADVS <- radvs(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
 #' ADVS
 #'
-#' ADVS <- radvs(ADSL, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
+#' ADVS <- radvs(adsl, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
 #' ADVS
-radvs <- function(ADSL,
+radvs <- function(adsl,
                   param = c(
                     "Diastolic Blood Pressure",
                     "Pulse Rate",
@@ -52,7 +52,7 @@ radvs <- function(ADSL,
     return(get_cached_data("cadvs"))
   }
 
-  checkmate::assert_data_frame(ADSL)
+  checkmate::assert_data_frame(adsl)
   checkmate::assert_character(param, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramcd, min.len = 1, any.missing = FALSE)
   checkmate::assert_character(paramu, min.len = 1, any.missing = FALSE)
@@ -70,11 +70,11 @@ radvs <- function(ADSL,
   if (!is.null(seed)) {
     set.seed(seed)
   }
-  study_duration_secs <- lubridate::seconds(attr(ADSL, "study_duration_secs"))
+  study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
   ADVS <- expand.grid(
-    STUDYID = unique(ADSL$STUDYID),
-    USUBJID = ADSL$USUBJID,
+    STUDYID = unique(adsl$STUDYID),
+    USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
     AVISIT = visit_schedule(visit_format = visit_format, n_assessments = n_assessments),
     stringsAsFactors = FALSE
@@ -123,7 +123,7 @@ radvs <- function(ADSL,
   ADVS <- ADVS[order(ADVS$STUDYID, ADVS$USUBJID, ADVS$PARAMCD, ADVS$AVISITN), ]
 
   ADVS <- Reduce(rbind, lapply(split(ADVS, ADVS$USUBJID), function(x) {
-    x$STUDYID <- ADSL$STUDYID[which(ADSL$USUBJID == x$USUBJID[1])]
+    x$STUDYID <- adsl$STUDYID[which(adsl$USUBJID == x$USUBJID[1])]
     x$ABLFL2 <- ifelse(x$AVISIT == "SCREENING", "Y", "")
     x$ABLFL <- ifelse(
       toupper(visit_format) == "WEEK" & x$AVISIT == "BASELINE",
@@ -186,8 +186,8 @@ radvs <- function(ADSL,
     dplyr::mutate(ATPTN = 1) %>%
     dplyr::mutate(DTYPE = NA) %>%
     var_relabel(
-      USUBJID = attr(ADSL$USUBJID, "label"),
-      STUDYID = attr(ADSL$STUDYID, "label")
+      USUBJID = attr(adsl$USUBJID, "label"),
+      STUDYID = attr(adsl$STUDYID, "label")
     )
 
   ADVS <- var_relabel(
@@ -199,7 +199,7 @@ radvs <- function(ADSL,
   # merge ADSL to be able to add LB date and study day variables
   ADVS <- dplyr::inner_join(
     ADVS,
-    ADSL,
+    adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
     dplyr::rowwise() %>%

--- a/R/radvs.R
+++ b/R/radvs.R
@@ -22,11 +22,11 @@
 #' library(random.cdisc.data)
 #' adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 #'
-#' ADVS <- radvs(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
-#' ADVS
+#' advs <- radvs(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+#' advs
 #'
-#' ADVS <- radvs(adsl, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
-#' ADVS
+#' advs <- radvs(adsl, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
+#' advs
 radvs <- function(adsl,
                   param = c(
                     "Diastolic Blood Pressure",
@@ -72,7 +72,7 @@ radvs <- function(adsl,
   }
   study_duration_secs <- lubridate::seconds(attr(adsl, "study_duration_secs"))
 
-  ADVS <- expand.grid(
+  advs <- expand.grid(
     STUDYID = unique(adsl$STUDYID),
     USUBJID = adsl$USUBJID,
     PARAM = as.factor(param_init_list$relvar1),
@@ -80,8 +80,8 @@ radvs <- function(adsl,
     stringsAsFactors = FALSE
   )
 
-  ADVS <- dplyr::mutate(
-    ADVS,
+  advs <- dplyr::mutate(
+    advs,
     AVISITN = dplyr::case_when(
       AVISIT == "SCREENING" ~ -1,
       AVISIT == "BASELINE" ~ 0,
@@ -90,39 +90,39 @@ radvs <- function(adsl,
     )
   )
 
-  ADVS$VSCAT <- "VITAL SIGNS"
+  advs$VSCAT <- "VITAL SIGNS"
 
   # assign related variable values: PARAMxPARAMCD are related
-  ADVS <- ADVS %>% rel_var(
+  advs <- advs %>% rel_var(
     var_name = "PARAMCD",
     related_var = "PARAM",
     var_values = param_init_list$relvar2
   )
 
   # assign related variable values: PARAMxAVALU are related
-  ADVS <- ADVS %>% rel_var(
+  advs <- advs %>% rel_var(
     var_name = "AVALU",
     related_var = "PARAM",
     var_values = unit_init_list$relvar2
   )
 
-  ADVS <- ADVS %>%
+  advs <- advs %>%
     dplyr::mutate(VSTESTCD = PARAMCD) %>%
     dplyr::mutate(VSTEST = PARAM)
 
-  ADVS <- ADVS %>% dplyr::mutate(AVAL = dplyr::case_when(
-    PARAMCD == paramcd[1] ~ stats::rnorm(nrow(ADVS), mean = 100, sd = 20),
-    PARAMCD == paramcd[2] ~ stats::rnorm(nrow(ADVS), mean = 80, sd = 15),
-    PARAMCD == paramcd[3] ~ stats::rnorm(nrow(ADVS), mean = 16, sd = 5),
-    PARAMCD == paramcd[4] ~ stats::rnorm(nrow(ADVS), mean = 150, sd = 30),
-    PARAMCD == paramcd[5] ~ stats::rnorm(nrow(ADVS), mean = 36.65, sd = 1),
-    PARAMCD == paramcd[6] ~ stats::rnorm(nrow(ADVS), mean = 70, sd = 20)
+  advs <- advs %>% dplyr::mutate(AVAL = dplyr::case_when(
+    PARAMCD == paramcd[1] ~ stats::rnorm(nrow(advs), mean = 100, sd = 20),
+    PARAMCD == paramcd[2] ~ stats::rnorm(nrow(advs), mean = 80, sd = 15),
+    PARAMCD == paramcd[3] ~ stats::rnorm(nrow(advs), mean = 16, sd = 5),
+    PARAMCD == paramcd[4] ~ stats::rnorm(nrow(advs), mean = 150, sd = 30),
+    PARAMCD == paramcd[5] ~ stats::rnorm(nrow(advs), mean = 36.65, sd = 1),
+    PARAMCD == paramcd[6] ~ stats::rnorm(nrow(advs), mean = 70, sd = 20)
   ))
 
   # order to prepare for change from screening and baseline values
-  ADVS <- ADVS[order(ADVS$STUDYID, ADVS$USUBJID, ADVS$PARAMCD, ADVS$AVISITN), ]
+  advs <- advs[order(advs$STUDYID, advs$USUBJID, advs$PARAMCD, advs$AVISITN), ]
 
-  ADVS <- Reduce(rbind, lapply(split(ADVS, ADVS$USUBJID), function(x) {
+  advs <- Reduce(rbind, lapply(split(advs, advs$USUBJID), function(x) {
     x$STUDYID <- adsl$STUDYID[which(adsl$USUBJID == x$USUBJID[1])]
     x$ABLFL2 <- ifelse(x$AVISIT == "SCREENING", "Y", "")
     x$ABLFL <- ifelse(
@@ -137,10 +137,10 @@ radvs <- function(adsl,
     x
   }))
 
-  ADVS$BASE2 <- retain(ADVS, ADVS$AVAL, ADVS$ABLFL2 == "Y")
-  ADVS$BASE <- ifelse(ADVS$ABLFL2 != "Y", retain(ADVS, ADVS$AVAL, ADVS$ABLFL == "Y"), NA)
+  advs$BASE2 <- retain(advs, advs$AVAL, advs$ABLFL2 == "Y")
+  advs$BASE <- ifelse(advs$ABLFL2 != "Y", retain(advs, advs$AVAL, advs$ABLFL == "Y"), NA)
 
-  ADVS <- ADVS %>%
+  advs <- advs %>%
     dplyr::mutate(CHG2 = AVAL - BASE2) %>%
     dplyr::mutate(PCHG2 = 100 * (CHG2 / BASE2)) %>%
     dplyr::mutate(CHG = AVAL - BASE) %>%
@@ -190,15 +190,15 @@ radvs <- function(adsl,
       STUDYID = attr(adsl$STUDYID, "label")
     )
 
-  ADVS <- var_relabel(
-    ADVS,
+  advs <- var_relabel(
+    advs,
     STUDYID = "Study Identifier",
     USUBJID = "Unique Subject Identifier"
   )
 
   # merge ADSL to be able to add LB date and study day variables
-  ADVS <- dplyr::inner_join(
-    ADVS,
+  advs <- dplyr::inner_join(
+    advs,
     adsl,
     by = c("STUDYID", "USUBJID")
   ) %>%
@@ -209,7 +209,7 @@ radvs <- function(adsl,
     ))) %>%
     dplyr::ungroup()
 
-  ADVS <- ADVS %>%
+  advs <- advs %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::arrange(USUBJID, AVISITN) %>%
     dplyr::mutate(ADTM = rep(
@@ -224,12 +224,12 @@ radvs <- function(adsl,
     dplyr::select(-TRTENDT) %>%
     dplyr::arrange(STUDYID, USUBJID, ADTM)
 
-  ADVS <- ADVS %>% dplyr::mutate(ONTRTFL = factor(dplyr::case_when(
+  advs <- advs %>% dplyr::mutate(ONTRTFL = factor(dplyr::case_when(
     !AVISIT %in% c("SCREENING", "BASELINE") ~ "Y",
     TRUE ~ ""
   )))
 
-  ADVS <- ADVS %>%
+  advs <- advs %>%
     dplyr::mutate(ASPID = sample(seq_len(dplyr::n()))) %>%
     dplyr::group_by(USUBJID) %>%
     dplyr::mutate(VSSEQ = seq_len(dplyr::n())) %>%
@@ -249,11 +249,11 @@ radvs <- function(adsl,
     )
 
   if (length(na_vars) > 0 && na_percentage > 0) {
-    ADVS <- mutate_na(ds = ADVS, na_vars = na_vars, na_percentage = na_percentage)
+    advs <- mutate_na(ds = advs, na_vars = na_vars, na_percentage = na_percentage)
   }
 
   # apply metadata
-  ADVS <- apply_metadata(ADVS, "metadata/ADVS.yml")
+  advs <- apply_metadata(advs, "metadata/advs.yml")
 
-  return(ADVS)
+  return(advs)
 }

--- a/R/radvs.R
+++ b/R/radvs.R
@@ -253,7 +253,7 @@ radvs <- function(adsl,
   }
 
   # apply metadata
-  advs <- apply_metadata(advs, "metadata/advs.yml")
+  advs <- apply_metadata(advs, "metadata/ADVS.yml")
 
   return(advs)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -80,7 +80,7 @@ relvar_init <- function(relvar1, relvar2) {
 #' @examples
 #' # Example with data.frame.
 #' params <- c("Level A", "Level B", "Level C")
-#' ADLB_df <- data.frame(
+#' adlb_df <- data.frame(
 #'   ID = 1:9,
 #'   PARAM = factor(
 #'     rep(c("Level A", "Level B", "Level C"), 3),
@@ -88,14 +88,14 @@ relvar_init <- function(relvar1, relvar2) {
 #'   )
 #' )
 #' random.cdisc.data:::rel_var(
-#'   df = ADLB_df,
+#'   df = adlb_df,
 #'   var_name = "PARAMCD",
 #'   var_values = c("A", "B", "C"),
 #'   related_var = "PARAM"
 #' )
 #'
 #' # Example with tibble.
-#' ADLB_tbl <- tibble::tibble(
+#' adlb_tbl <- tibble::tibble(
 #'   ID = 1:9,
 #'   PARAM = factor(
 #'     rep(c("Level A", "Level B", "Level C"), 3),
@@ -103,7 +103,7 @@ relvar_init <- function(relvar1, relvar2) {
 #'   )
 #' )
 #' random.cdisc.data:::rel_var(
-#'   df = ADLB_tbl,
+#'   df = adlb_tbl,
 #'   var_name = "PARAMCD",
 #'   var_values = c("A", "B", "C"),
 #'   related_var = "PARAM"
@@ -177,10 +177,10 @@ visit_schedule <- function(visit_format = "WEEK",
 #' @keywords internal
 #'
 #' @examples
-#' ADLB <- radlb(radsl(N = 10, na_percentage = 0), na_vars = list())
-#' ADLB$BASE2 <- random.cdisc.data:::retain(
-#'   df = ADLB, value_var = ADLB$AVAL,
-#'   event = ADLB$ABLFL2 == "Y"
+#' adlb <- radlb(radsl(N = 10, na_percentage = 0), na_vars = list())
+#' adlb$BASE2 <- random.cdisc.data:::retain(
+#'   df = adlb, value_var = adlb$AVAL,
+#'   event = adlb$ABLFL2 == "Y"
 #' )
 retain <- function(df, value_var, event, outside = NA) {
   indices <- c(1, which(event == TRUE), nrow(df) + 1)
@@ -231,16 +231,16 @@ var_relabel <- function(x, ...) {
 #' @examples
 #' seed <- 1
 #' adsl <- radsl(seed = seed)
-#' ADLB <- radlb(adsl, seed = seed)
+#' adlb <- radlb(adsl, seed = seed)
 #' \dontrun{
 #' yaml_path <- file.path(path.package("random.cdisc.data"), "inst", "metadata")
-#' adsl <- random.cdisc.data:::apply_metadata(adsl, file.path(yaml_path, "ADSL.yml"), FALSE)
-#' ADLB <- random.cdisc.data:::apply_metadata(
-#'   ADLB, file.path(yaml_path, "ADLB.yml"), TRUE,
-#'   file.path(yaml_path, "ADSL.yml")
+#' adsl <- random.cdisc.data:::apply_metadata(adsl, file.path(yaml_path, "adsl.yml"), FALSE)
+#' adlb <- random.cdisc.data:::apply_metadata(
+#'   adlb, file.path(yaml_path, "adlb.yml"), TRUE,
+#'   file.path(yaml_path, "adsl.yml")
 #' )
 #' }
-apply_metadata <- function(df, filename, add_adsl = TRUE, adsl_filename = "metadata/ADSL.yml") {
+apply_metadata <- function(df, filename, add_adsl = TRUE, adsl_filename = "metadata/adsl.yml") {
   checkmate::assert_data_frame(df)
   checkmate::assert_string(filename)
   checkmate::assert_flag(add_adsl)

--- a/R/utils.R
+++ b/R/utils.R
@@ -199,8 +199,8 @@ retain <- function(df, value_var, event, outside = NA) {
 #' @keywords internal
 #'
 #' @examples
-#' ADSL <- radsl()
-#' random.cdisc.data:::var_relabel(ADSL,
+#' adsl <- radsl()
+#' random.cdisc.data:::var_relabel(adsl,
 #'   STUDYID = "Study Identifier",
 #'   USUBJID = "Unique Subject Identifier"
 #' )
@@ -230,11 +230,11 @@ var_relabel <- function(x, ...) {
 #'
 #' @examples
 #' seed <- 1
-#' ADSL <- radsl(seed = seed)
-#' ADLB <- radlb(ADSL, seed = seed)
+#' adsl <- radsl(seed = seed)
+#' ADLB <- radlb(adsl, seed = seed)
 #' \dontrun{
 #' yaml_path <- file.path(path.package("random.cdisc.data"), "inst", "metadata")
-#' ADSL <- random.cdisc.data:::apply_metadata(ADSL, file.path(yaml_path, "ADSL.yml"), FALSE)
+#' adsl <- random.cdisc.data:::apply_metadata(adsl, file.path(yaml_path, "ADSL.yml"), FALSE)
 #' ADLB <- random.cdisc.data:::apply_metadata(
 #'   ADLB, file.path(yaml_path, "ADLB.yml"), TRUE,
 #'   file.path(yaml_path, "ADSL.yml")

--- a/R/utils.R
+++ b/R/utils.R
@@ -234,13 +234,13 @@ var_relabel <- function(x, ...) {
 #' adlb <- radlb(adsl, seed = seed)
 #' \dontrun{
 #' yaml_path <- file.path(path.package("random.cdisc.data"), "inst", "metadata")
-#' adsl <- random.cdisc.data:::apply_metadata(adsl, file.path(yaml_path, "adsl.yml"), FALSE)
+#' adsl <- random.cdisc.data:::apply_metadata(adsl, file.path(yaml_path, "ADSL.yml"), FALSE)
 #' adlb <- random.cdisc.data:::apply_metadata(
-#'   adlb, file.path(yaml_path, "adlb.yml"), TRUE,
-#'   file.path(yaml_path, "adsl.yml")
+#'   adlb, file.path(yaml_path, "ADLB.yml"), TRUE,
+#'   file.path(yaml_path, "ADSL.yml")
 #' )
 #' }
-apply_metadata <- function(df, filename, add_adsl = TRUE, adsl_filename = "metadata/adsl.yml") {
+apply_metadata <- function(df, filename, add_adsl = TRUE, adsl_filename = "metadata/ADSL.yml") {
   checkmate::assert_data_frame(df)
   checkmate::assert_string(filename)
   checkmate::assert_flag(add_adsl)

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,7 +31,7 @@ get_cached_data <- function(dataname) {
 #' @examples
 #' random.cdisc.data:::sample_fct(letters[1:3], 10)
 #' random.cdisc.data:::sample_fct(iris$Species, 10)
-sample_fct <- function(x, N, ...) {
+sample_fct <- function(x, N, ...) { # nolint
   checkmate::assert_number(N)
 
   factor(sample(x, N, replace = TRUE, ...), levels = if (is.factor(x)) levels(x) else x)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -69,6 +69,7 @@ dipietrc
 funder
 metres
 npaszty
+rdata
 repo
 tomlinsj
 wojciakw

--- a/man/apply_metadata.Rd
+++ b/man/apply_metadata.Rd
@@ -25,13 +25,13 @@ Apply label and variable ordering attributes to domains.
 }
 \examples{
 seed <- 1
-ADSL <- radsl(seed = seed)
-ADLB <- radlb(ADSL, seed = seed)
+adsl <- radsl(seed = seed)
+adlb <- radlb(adsl, seed = seed)
 \dontrun{
 yaml_path <- file.path(path.package("random.cdisc.data"), "inst", "metadata")
-ADSL <- random.cdisc.data:::apply_metadata(ADSL, file.path(yaml_path, "ADSL.yml"), FALSE)
-ADLB <- random.cdisc.data:::apply_metadata(
-  ADLB, file.path(yaml_path, "ADLB.yml"), TRUE,
+adsl <- random.cdisc.data:::apply_metadata(adsl, file.path(yaml_path, "ADSL.yml"), FALSE)
+adlb <- random.cdisc.data:::apply_metadata(
+  adlb, file.path(yaml_path, "ADLB.yml"), TRUE,
   file.path(yaml_path, "ADSL.yml")
 )
 }

--- a/man/argument_convention.Rd
+++ b/man/argument_convention.Rd
@@ -16,7 +16,7 @@ element of this list should be a numeric vector with two elements:
 If \code{NA}, \code{na_percentage} is used as a default.}
 }}
 
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{lookup}{(\code{data.frame})\cr Additional parameters.}
 

--- a/man/h_adqlqc.Rd
+++ b/man/h_adqlqc.Rd
@@ -11,7 +11,7 @@
 \title{Helper Functions for Constructing ADQLQC}
 \usage{
 get_qs_data(
-  ADSL,
+  adsl,
   visit_format = "CYCLE",
   n_assessments = 5L,
   n_days = 1L,
@@ -32,7 +32,7 @@ derv_chgcat1(dataset)
 comp_derv(dataset, percent, number)
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{visit_format}{(\code{character})\cr Type of visit. Options are "WEEK" and "CYCLE".}
 
@@ -104,14 +104,14 @@ Function for generating random Questionnaires SDTM domain
 
 }}
 \examples{
-ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
-ADQLQC <- radqlqc(ADSL, seed = 1, percent = 80, number = 2)
+adsl <- radsl(N = 10, study_duration = 2, seed = 1)
+adqlqc <- radqlqc(adsl, seed = 1, percent = 80, number = 2)
 
-QS <- random.cdisc.data:::get_qs_data(ADSL, n_assessments = 5L, seed = 1, na_percentage = 0.1)
-QS
+qs <- random.cdisc.data:::get_qs_data(adsl, n_assessments = 5L, seed = 1, na_percentage = 0.1)
+qs
 df <- dplyr::left_join(
-  ADSL,
-  QS,
+  adsl,
+  qs,
   by = c("STUDYID", "USUBJID"),
   multiple = "all"
 ) |>
@@ -122,13 +122,13 @@ df <- dplyr::left_join(
   ) |>
   dplyr::mutate(ADTM = random.cdisc.data:::get_random_dates_between(TRTSDTM, TRTEDTM, AVISITN))
 df
-ADQLQC1 <- random.cdisc.data:::prep_adqlqc(df = QS)
-ADQLQC1
+adqlqc1 <- random.cdisc.data:::prep_adqlqc(df = qs)
+adqlqc1
 df_scales <- random.cdisc.data:::calc_scales(df)
 df_scales
-ADQLQC <- random.cdisc.data:::derv_chgcat1(dataset = ADQLQC |> dplyr::select(-CHGCAT1))
-ADQLQC
-compliance_data <- random.cdisc.data:::comp_derv(ADQLQC, 80, 2)
+adqlqc <- random.cdisc.data:::derv_chgcat1(dataset = adqlqc |> dplyr::select(-CHGCAT1))
+adqlqc
+compliance_data <- random.cdisc.data:::comp_derv(adqlqc, 80, 2)
 compliance_data
 }
 \keyword{internal}

--- a/man/h_anthropometrics_by_sex.Rd
+++ b/man/h_anthropometrics_by_sex.Rd
@@ -49,9 +49,9 @@ One record per subject.
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 5, seed = 1)
+adsl <- radsl(N = 5, seed = 1)
 
-df_with_measurements <- random.cdisc.data:::h_anthropometrics_by_sex(df = ADSL)
+df_with_measurements <- random.cdisc.data:::h_anthropometrics_by_sex(df = adsl)
 df_with_measurements
 }
 \keyword{internal}

--- a/man/radab.Rd
+++ b/man/radab.Rd
@@ -5,8 +5,8 @@
 \title{Anti-Drug Antibody Analysis Dataset (ADAB)}
 \usage{
 radab(
-  ADSL,
-  ADPC,
+  adsl,
+  adpc,
   constants = c(D = 100, ka = 0.8, ke = 1),
   paramcd = c("R1800000", "RESULT1", "R1800001", "RESULT2", "ADASTAT1", "INDUCD1",
     "ENHANC1", "TRUNAFF1", "EMERNEG1", "EMERPOS1", "PERSADA1", "TRANADA1", "BFLAG1",
@@ -33,9 +33,9 @@ radab(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
-\item{ADPC}{(\code{data.frame})\cr Pharmacokinetics Analysis Dataset.}
+\item{adpc}{(\code{data.frame})\cr Pharmacokinetics Analysis Dataset.}
 
 \item{constants}{(\verb{character vector})\cr Constant parameters to be used in formulas for creating analysis values.}
 
@@ -74,9 +74,9 @@ One record per study per subject per parameter per time point.
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
-ADPC <- radpc(ADSL, seed = 2, duration = 9 * 7)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
+adpc <- radpc(adsl, seed = 2, duration = 9 * 7)
 
-ADAB <- radab(ADSL, ADPC, seed = 2)
-ADAB
+adab <- radab(adsl, adpc, seed = 2)
+adab
 }

--- a/man/radae.Rd
+++ b/man/radae.Rd
@@ -5,7 +5,7 @@
 \title{Adverse Event Analysis Dataset (ADAE)}
 \usage{
 radae(
-  ADSL,
+  adsl,
   max_n_aes = 10L,
   lookup = NULL,
   lookup_aag = NULL,
@@ -16,7 +16,7 @@ radae(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{max_n_aes}{(\code{integer})\cr Maximum number of AEs per patient. Defaults to 10.}
 
@@ -55,13 +55,13 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{ASTDTM}, \code{AETERM}, \code{AESEQ}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
+adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 
-ADAE <- radae(ADSL, seed = 2)
-ADAE
+adae <- radae(adsl, seed = 2)
+adae
 
 # Add metadata.
-AAG <- utils::read.table(
+aag <- utils::read.table(
   sep = ",", header = TRUE,
   text = paste(
     "NAMVAR,SRCVAR,GRPTYPE,REFNAME,REFTERM,SCOPE",
@@ -75,10 +75,10 @@ AAG <- utils::read.table(
   ), stringsAsFactors = FALSE
 )
 
-ADAE <- radae(ADSL, lookup_aag = AAG)
+adae <- radae(adsl, lookup_aag = aag)
 
 with(
-  ADAE,
+  adae,
   cbind(
     table(AEDECOD, SMQ01NAM),
     table(AEDECOD, CQ01NAM)

--- a/man/radaette.Rd
+++ b/man/radaette.Rd
@@ -5,9 +5,9 @@
 \title{Time to Adverse Event Analysis Dataset (ADAETTE)}
 \usage{
 radaette(
-  ADSL,
-  event.descr = NULL,
-  censor.descr = NULL,
+  adsl,
+  event_descr = NULL,
+  censor_descr = NULL,
   lookup = NULL,
   seed = NULL,
   na_percentage = 0,
@@ -16,11 +16,11 @@ radaette(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
-\item{event.descr}{(\verb{character vector})\cr Descriptions of events. Defaults to \code{NULL}.}
+\item{event_descr}{(\verb{character vector})\cr Descriptions of events. Defaults to \code{NULL}.}
 
-\item{censor.descr}{(\verb{character vector})\cr Descriptions of censors. Defaults to \code{NULL}.}
+\item{censor_descr}{(\verb{character vector})\cr Descriptions of censors. Defaults to \code{NULL}.}
 
 \item{lookup}{(\code{data.frame})\cr Additional parameters.}
 
@@ -53,10 +53,10 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADAETTE <- radaette(ADSL, seed = 2)
-ADAETTE
+adaette <- radaette(adsl, seed = 2)
+adaette
 }
 \author{
 Xiuting Mi

--- a/man/radcm.Rd
+++ b/man/radcm.Rd
@@ -5,7 +5,7 @@
 \title{Previous and Concomitant Medications Analysis Dataset (ADCM)}
 \usage{
 radcm(
-  ADSL,
+  adsl,
   max_n_cms = 10L,
   lookup = NULL,
   seed = NULL,
@@ -16,7 +16,7 @@ radcm(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{max_n_cms}{(\code{integer})\cr Maximum number of concomitant medications per patient. Defaults to 10.}
 
@@ -55,11 +55,11 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{ASTDTM}, \code{CMSEQ}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADCM <- radcm(ADSL, seed = 2)
-ADCM
+adcm <- radcm(adsl, seed = 2)
+adcm
 
-ADCM_WHO <- radcm(ADSL, seed = 2, who_coding = TRUE)
-ADCM_WHO
+adcm_who <- radcm(adsl, seed = 2, who_coding = TRUE)
+adcm_who
 }

--- a/man/raddv.Rd
+++ b/man/raddv.Rd
@@ -5,7 +5,7 @@
 \title{Protocol Deviations Analysis Dataset (ADDV)}
 \usage{
 raddv(
-  ADSL,
+  adsl,
   max_n_dv = 3L,
   p_dv = 0.15,
   lookup = NULL,
@@ -17,7 +17,7 @@ raddv(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{max_n_dv}{(\code{integer})\cr Maximum number of deviations per patient. Defaults to 3.}
 
@@ -56,8 +56,8 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{ASTDT}, \code{DVTERM}, \code{DVSEQ}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADDV <- raddv(ADSL, seed = 2)
-ADDV
+addv <- raddv(adsl, seed = 2)
+addv
 }

--- a/man/radeg.Rd
+++ b/man/radeg.Rd
@@ -5,7 +5,7 @@
 \title{ECG Analysis Dataset (ADEG)}
 \usage{
 radeg(
-  ADSL,
+  adsl,
   egcat = c("INTERVAL", "INTERVAL", "MEASUREMENT", "FINDING"),
   param = c("QT Duration", "RR Duration", "Heart Rate", "ECG Interpretation"),
   paramcd = c("QT", "RR", "HR", "ECGINTP"),
@@ -23,7 +23,7 @@ radeg(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{egcat}{(\verb{character vector})\cr EG category values.}
 
@@ -74,13 +74,13 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}, \code{BASETYPE}, \code{AVI
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADEG <- radeg(ADSL, visit_format = "WEEK", n_assessments = 7L, seed = 2)
-ADEG
+adeg <- radeg(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+adeg
 
-ADEG <- radeg(ADSL, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
-ADEG
+adeg <- radeg(adsl, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
+adeg
 }
 \author{
 tomlinsj, npaszty, Xuefeng Hou, dipietrc

--- a/man/radex.Rd
+++ b/man/radex.Rd
@@ -5,7 +5,7 @@
 \title{Exposure Analysis Dataset (ADEX)}
 \usage{
 radex(
-  ADSL,
+  adsl,
   param = c("Dose administered during constant dosing interval",
     "Number of doses administered during constant dosing interval",
     "Total dose administered", "Total number of doses administered"),
@@ -25,7 +25,7 @@ radex(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{param}{(\verb{character vector})\cr Parameter values.}
 
@@ -79,8 +79,8 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{EXSEQ}, \code{PARAMCD}, \code{PARCAT
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
+adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 
-ADEX <- radex(ADSL, seed = 2)
-ADEX
+adex <- radex(adsl, seed = 2)
+adex
 }

--- a/man/radhy.Rd
+++ b/man/radhy.Rd
@@ -5,7 +5,7 @@
 \title{Hy's Law Analysis Dataset (ADHY)}
 \usage{
 radhy(
-  ADSL,
+  adsl,
   param = c("TBILI <= 2 times ULN and ALT value category",
     "TBILI > 2 times ULN and AST value category",
     "TBILI > 2 times ULN and ALT value category",
@@ -36,7 +36,7 @@ radhy(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{param}{(\verb{character vector})\cr Parameter values.}
 
@@ -63,10 +63,10 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}, \code{AVISITN}, \code{ADTM
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADHY <- radhy(ADSL, seed = 2)
-ADHY
+adhy <- radhy(adsl, seed = 2)
+adhy
 }
 \author{
 wojciakw

--- a/man/radlb.Rd
+++ b/man/radlb.Rd
@@ -5,7 +5,7 @@
 \title{Laboratory Data Analysis Dataset (ADLB)}
 \usage{
 radlb(
-  ADSL,
+  adsl,
   lbcat = c("CHEMISTRY", "CHEMISTRY", "IMMUNOLOGY"),
   param = c("Alanine Aminotransferase Measurement", "C-Reactive Protein Measurement",
     "Immunoglobulin A Measurement"),
@@ -26,7 +26,7 @@ radlb(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{lbcat}{(\verb{character vector})\cr LB category values.}
 
@@ -79,13 +79,13 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}, \code{BASETYPE}, \code{AVI
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADLB <- radlb(ADSL, visit_format = "WEEK", n_assessments = 7L, seed = 2)
-ADLB
+adlb <- radlb(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+adlb
 
-ADLB <- radlb(ADSL, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
-ADLB
+adlb <- radlb(adsl, visit_format = "CYCLE", n_assessments = 2L, seed = 2)
+adlb
 }
 \author{
 tomlinsj, npaszty, Xuefeng Hou

--- a/man/radmh.Rd
+++ b/man/radmh.Rd
@@ -5,7 +5,7 @@
 \title{Medical History Analysis Dataset (ADMH)}
 \usage{
 radmh(
-  ADSL,
+  adsl,
   max_n_mhs = 10L,
   lookup = NULL,
   seed = NULL,
@@ -15,7 +15,7 @@ radmh(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{max_n_mhs}{(\code{integer})\cr Maximum number of MHs per patient. Defaults to 10.}
 
@@ -52,8 +52,8 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{ASTDTM}, \code{MHSEQ}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
+adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 
-ADMH <- radmh(ADSL, seed = 2)
-ADMH
+admh <- radmh(adsl, seed = 2)
+admh
 }

--- a/man/radpc.Rd
+++ b/man/radpc.Rd
@@ -5,7 +5,7 @@
 \title{Pharmacokinetics Analysis Dataset (ADPC)}
 \usage{
 radpc(
-  ADSL,
+  adsl,
   avalu = "ug/mL",
   constants = c(D = 100, ka = 0.8, ke = 1),
   duration = 2,
@@ -16,7 +16,7 @@ radpc(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{avalu}{(\code{character})\cr Analysis value units.}
 
@@ -53,11 +53,11 @@ One record per study, subject, parameter, and time point.
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADPC <- radpc(ADSL, seed = 2)
-ADPC
+adpc <- radpc(adsl, seed = 2)
+adpc
 
-ADPC <- radpc(ADSL, seed = 2, duration = 3)
-ADPC
+adpc <- radpc(adsl, seed = 2, duration = 3)
+adpc
 }

--- a/man/radpp.Rd
+++ b/man/radpp.Rd
@@ -5,7 +5,7 @@
 \title{Pharmacokinetics Parameters Dataset (ADPP)}
 \usage{
 radpp(
-  ADSL,
+  adsl,
   ppcat = c("Plasma Drug X", "Plasma Drug Y", "Metabolite Drug X", "Metabolite Drug Y"),
   ppspec = c("Plasma", "Plasma", "Plasma", "Matrix of PD", "Matrix of PD", "Urine",
     "Urine", "Urine", "Urine"),
@@ -26,7 +26,7 @@ radpp(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{ppcat}{(\verb{character vector})\cr Categories of parameters.}
 
@@ -73,8 +73,8 @@ One record per study, subject, parameter category, parameter and visit.
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADPP <- radpp(ADSL, seed = 2)
-ADPP
+adpp <- radpp(adsl, seed = 2)
+adpp
 }

--- a/man/radqlqc.Rd
+++ b/man/radqlqc.Rd
@@ -4,10 +4,10 @@
 \alias{radqlqc}
 \title{EORTC QLQ-C30 V3 Analysis Dataset (ADQLQC)}
 \usage{
-radqlqc(ADSL, percent, number, seed = NULL, cached = FALSE)
+radqlqc(adsl, percent, number, seed = NULL, cached = FALSE)
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{percent}{(\code{numeric})\cr Completion - Completed at least y percent of questions, 1 record per visit}
 
@@ -32,8 +32,8 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARCAT1N}, \code{PARAMCD}, \code{BAS
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
+adsl <- radsl(N = 10, study_duration = 2, seed = 1)
 
-ADQLQC <- radqlqc(ADSL, seed = 1, percent = 80, number = 2)
-ADQLQC
+adqlqc <- radqlqc(adsl, seed = 1, percent = 80, number = 2)
+adqlqc
 }

--- a/man/radqs.Rd
+++ b/man/radqs.Rd
@@ -5,7 +5,7 @@
 \title{Questionnaires Analysis Dataset (ADQS)}
 \usage{
 radqs(
-  ADSL,
+  adsl,
   param = c("BFI All Questions", "Fatigue Interference",
     "Function/Well-Being (GF1,GF3,GF7)", "Treatment Side Effects (GP2,C5,GP5)",
     "FKSI-19 All Questions"),
@@ -21,7 +21,7 @@ radqs(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{param}{(\verb{character vector})\cr Parameter values.}
 
@@ -64,13 +64,13 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}, \code{AVISITN}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADQS <- radqs(ADSL, visit_format = "WEEK", n_assessments = 7L, seed = 2)
-ADQS
+adqs <- radqs(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+adqs
 
-ADQS <- radqs(ADSL, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
-ADQS
+adqs <- radqs(adsl, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
+adqs
 }
 \author{
 npaszty

--- a/man/radrs.Rd
+++ b/man/radrs.Rd
@@ -5,7 +5,7 @@
 \title{Tumor Response Analysis Dataset (ADRS)}
 \usage{
 radrs(
-  ADSL,
+  adsl,
   avalc = NULL,
   lookup = NULL,
   seed = NULL,
@@ -15,7 +15,7 @@ radrs(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{avalc}{(\verb{character vector})\cr Analysis value categories.}
 
@@ -54,8 +54,8 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}, \code{AVISITN}, \code{ADT}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADRS <- radrs(ADSL, seed = 2)
-ADRS
+adrs <- radrs(adsl, seed = 2)
+adrs
 }

--- a/man/radsaftte.Rd
+++ b/man/radsaftte.Rd
@@ -4,10 +4,10 @@
 \alias{radsaftte}
 \title{Time to Safety Event Analysis Dataset (ADSAFTTE)}
 \usage{
-radsaftte(ADSL, ...)
+radsaftte(adsl, ...)
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{...}{Additional arguments to be passed to \code{radaette}}
 }
@@ -23,8 +23,8 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADSAFTTE <- radsaftte(ADSL, seed = 2)
-ADSAFTTE
+adsaftte <- radsaftte(adsl, seed = 2)
+adsaftte
 }

--- a/man/radsl.Rd
+++ b/man/radsl.Rd
@@ -62,10 +62,10 @@ Keys: \code{STUDYID}, \code{USUBJID}
 \examples{
 library(random.cdisc.data)
 
-ADSL <- radsl(N = 10, study_duration = 2, seed = 1)
-ADSL
+adsl <- radsl(N = 10, study_duration = 2, seed = 1)
+adsl
 
-ADSL <- radsl(
+adsl <- radsl(
   N = 10, seed = 1,
   na_percentage = 0.1,
   na_vars = list(
@@ -73,8 +73,8 @@ ADSL <- radsl(
     LSTALVDT = c(seed = 1234, percentage = 0.1)
   )
 )
-ADSL
+adsl
 
-ADSL <- radsl(N = 10, seed = 1, na_percentage = .1)
-ADSL
+adsl <- radsl(N = 10, seed = 1, na_percentage = .1)
+adsl
 }

--- a/man/radsub.Rd
+++ b/man/radsub.Rd
@@ -5,7 +5,7 @@
 \title{Subcategory Analysis Dataset (ADSUB)}
 \usage{
 radsub(
-  ADSL,
+  adsl,
   param = c("Baseline Weight", "Baseline Height", "Baseline BMI", "Baseline ECOG",
     "Baseline Biomarker Mutation"),
   paramcd = c("BWGHTSI", "BHGHTSI", "BBMISI", "BECOG", "BBMRKR1"),
@@ -16,7 +16,7 @@ radsub(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{param}{(\verb{character vector})\cr Parameter values.}
 
@@ -53,10 +53,10 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}, \code{AVISITN}, \code{ADTM
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADSUB <- radsub(ADSL, seed = 2)
-ADSUB
+adsub <- radsub(adsl, seed = 2)
+adsub
 }
 \author{
 tomlinsj, npaszty, Xuefeng Hou, dipietrc

--- a/man/radtr.Rd
+++ b/man/radtr.Rd
@@ -5,7 +5,7 @@
 \title{Tumor Response Analysis Dataset (ADTR)}
 \usage{
 radtr(
-  ADSL,
+  adsl,
   param = c("Sum of Longest Diameter by Investigator"),
   paramcd = c("SLDINV"),
   seed = NULL,
@@ -14,7 +14,7 @@ radtr(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{param}{(\verb{character vector})\cr Parameter values.}
 
@@ -43,10 +43,10 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}, \code{BASETYPE}, \code{AVI
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADTR <- radtr(ADSL, seed = 2)
-ADTR
+adtr <- radtr(adsl, seed = 2)
+adtr
 }
 \author{
 tomlinsj, npaszty, Xuefeng Hou, dipietrc

--- a/man/radtte.Rd
+++ b/man/radtte.Rd
@@ -5,9 +5,9 @@
 \title{Time-to-Event Analysis Dataset (ADTTE)}
 \usage{
 radtte(
-  ADSL,
-  event.descr = NULL,
-  censor.descr = NULL,
+  adsl,
+  event_descr = NULL,
+  censor_descr = NULL,
   lookup = NULL,
   seed = NULL,
   na_percentage = 0,
@@ -16,11 +16,11 @@ radtte(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
-\item{event.descr}{(\verb{character vector})\cr Descriptions of events. Defaults to \code{NULL}.}
+\item{event_descr}{(\verb{character vector})\cr Descriptions of events. Defaults to \code{NULL}.}
 
-\item{censor.descr}{(\verb{character vector})\cr Descriptions of censors. Defaults to \code{NULL}.}
+\item{censor_descr}{(\verb{character vector})\cr Descriptions of censors. Defaults to \code{NULL}.}
 
 \item{lookup}{(\code{data.frame})\cr Additional parameters.}
 
@@ -53,8 +53,8 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADTTE <- radtte(ADSL, seed = 2)
-ADTTE
+adtte <- radtte(adsl, seed = 2)
+adtte
 }

--- a/man/radvs.Rd
+++ b/man/radvs.Rd
@@ -5,7 +5,7 @@
 \title{Vital Signs Analysis Dataset (ADVS)}
 \usage{
 radvs(
-  ADSL,
+  adsl,
   param = c("Diastolic Blood Pressure", "Pulse Rate", "Respiratory Rate",
     "Systolic Blood Pressure", "Temperature", "Weight"),
   paramcd = c("DIABP", "PULSE", "RESP", "SYSBP", "TEMP", "WEIGHT"),
@@ -21,7 +21,7 @@ radvs(
 )
 }
 \arguments{
-\item{ADSL}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
+\item{adsl}{(\code{data.frame})\cr Subject-Level Analysis Dataset (ADSL).}
 
 \item{param}{(\verb{character vector})\cr Parameter values.}
 
@@ -66,13 +66,13 @@ Keys: \code{STUDYID}, \code{USUBJID}, \code{PARAMCD}, \code{BASETYPE}, \code{AVI
 }
 \examples{
 library(random.cdisc.data)
-ADSL <- radsl(N = 10, seed = 1, study_duration = 2)
+adsl <- radsl(N = 10, seed = 1, study_duration = 2)
 
-ADVS <- radvs(ADSL, visit_format = "WEEK", n_assessments = 7L, seed = 2)
-ADVS
+advs <- radvs(adsl, visit_format = "WEEK", n_assessments = 7L, seed = 2)
+advs
 
-ADVS <- radvs(ADSL, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
-ADVS
+advs <- radvs(adsl, visit_format = "CYCLE", n_assessments = 3L, seed = 2)
+advs
 }
 \author{
 npaszty

--- a/man/rel_var.Rd
+++ b/man/rel_var.Rd
@@ -25,7 +25,7 @@ Assign values to a related variable within a domain.
 \examples{
 # Example with data.frame.
 params <- c("Level A", "Level B", "Level C")
-ADLB_df <- data.frame(
+adlb_df <- data.frame(
   ID = 1:9,
   PARAM = factor(
     rep(c("Level A", "Level B", "Level C"), 3),
@@ -33,14 +33,14 @@ ADLB_df <- data.frame(
   )
 )
 random.cdisc.data:::rel_var(
-  df = ADLB_df,
+  df = adlb_df,
   var_name = "PARAMCD",
   var_values = c("A", "B", "C"),
   related_var = "PARAM"
 )
 
 # Example with tibble.
-ADLB_tbl <- tibble::tibble(
+adlb_tbl <- tibble::tibble(
   ID = 1:9,
   PARAM = factor(
     rep(c("Level A", "Level B", "Level C"), 3),
@@ -48,7 +48,7 @@ ADLB_tbl <- tibble::tibble(
   )
 )
 random.cdisc.data:::rel_var(
-  df = ADLB_tbl,
+  df = adlb_tbl,
   var_name = "PARAMCD",
   var_values = c("A", "B", "C"),
   related_var = "PARAM"

--- a/man/retain.Rd
+++ b/man/retain.Rd
@@ -19,10 +19,10 @@ retain(df, value_var, event, outside = NA)
 Retain values within primary keys.
 }
 \examples{
-ADLB <- radlb(radsl(N = 10, na_percentage = 0), na_vars = list())
-ADLB$BASE2 <- random.cdisc.data:::retain(
-  df = ADLB, value_var = ADLB$AVAL,
-  event = ADLB$ABLFL2 == "Y"
+adlb <- radlb(radsl(N = 10, na_percentage = 0), na_vars = list())
+adlb$BASE2 <- random.cdisc.data:::retain(
+  df = adlb, value_var = adlb$AVAL,
+  event = adlb$ABLFL2 == "Y"
 )
 }
 \keyword{internal}

--- a/man/var_relabel.Rd
+++ b/man/var_relabel.Rd
@@ -16,8 +16,8 @@ name in \code{x} and the value to the new variable label.}
 Relabel a subset of variables in a data set.
 }
 \examples{
-ADSL <- radsl()
-random.cdisc.data:::var_relabel(ADSL,
+adsl <- radsl()
+random.cdisc.data:::var_relabel(adsl,
   STUDYID = "Study Identifier",
   USUBJID = "Unique Subject Identifier"
 )


### PR DESCRIPTION
Closes #263 #264

Potential breaking changes: 
Changed parameters `ADSL` to `adsl`, `ADPC` to `adpc`, `event.descr` to `event_descr`, and `censor.descr` to `censor_descr` - I was unable to find any instances where these parameters were explicitly named and the changes would cause an issue. Are there any packages that call the rdata functions instead of using `scda` data?